### PR TITLE
Adding jdk field to vulcanizer nodes output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+# http://docs.travis-ci.com/user/languages/go/
+language: go
+
+go: 1.9
+
+os:
+    - linux
+
+env:
+  - YOUR_VAR=your_value
+
+install: true
+
+script: script/test
+
+notifications:
+    email: fals

--- a/cmd/vulcanizer/nodes.go
+++ b/cmd/vulcanizer/nodes.go
@@ -26,7 +26,7 @@ var cmdNodes = &cobra.Command{
 			os.Exit(1)
 		}
 
-		header := []string{"Master", "Role", "Name", "Ip", "Id"}
+		header := []string{"Master", "Role", "Name", "Ip", "Id", "JDK"}
 		rows := [][]string{}
 		for _, node := range nodes {
 			row := []string{
@@ -35,6 +35,7 @@ var cmdNodes = &cobra.Command{
 				node.Name,
 				node.Ip,
 				node.Id,
+				node.Jdk,
 			}
 
 			rows = append(rows, row)

--- a/es.go
+++ b/es.go
@@ -32,6 +32,7 @@ type Node struct {
 	Id     string `json:"id"`
 	Role   string `json:"role"`
 	Master string `json:"master"`
+	Jdk    string `json:"jdk"`
 }
 
 //Holds information about an Elasticsearch index, based on the _cat/indices API: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-indices.html
@@ -279,7 +280,7 @@ func (c *Client) FillAll() (ExcludeSettings, error) {
 func (c *Client) GetNodes() ([]Node, error) {
 	var nodes []Node
 
-	agent := c.buildGetRequest("_cat/nodes?h=master,role,name,ip,id")
+	agent := c.buildGetRequest("_cat/nodes?h=master,role,name,ip,id,jdk")
 	err := handleErrWithStruct(agent, &nodes)
 
 	if err != nil {

--- a/es_test.go
+++ b/es_test.go
@@ -231,7 +231,7 @@ func TestGetNodes(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "GET",
 		Path:     "/_cat/nodes",
-		Response: `[{"master": "*", "role": "d", "name": "foo", "ip": "127.0.0.1", "id": "abc"}]`,
+		Response: `[{"master": "*", "role": "d", "name": "foo", "ip": "127.0.0.1", "id": "abc", "jdk": "1.8"}]`,
 	}
 
 	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})


### PR DESCRIPTION
# Overview

This adds a JDK version so that JDK version mismatches can easily be seen on the node list.