### PR TITLE
Improve travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install: true
 script: script/test
 
 notifications:
-    email: fals
+    email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,16 @@
 language: go
 
 go:
- - "1.10.x"
- - "1.11.x"
+    - "1.10.x"
+    - "1.11.x"
 
 os:
     - linux
 
-env:
-  - YOUR_VAR=your_value
-
 install: true
+
+before_script:
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.11.2
 
 script: script/test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 # http://docs.travis-ci.com/user/languages/go/
 language: go
 
-go: 1.9
+go:
+ - "1.10.x"
+ - "1.11.x"
 
 os:
     - linux

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -17,7 +17,6 @@ if [ "$(uname -s)" = "Darwin" ]; then
 fi
 
 # Install linter. Should be universal. Version is pinned per package reccomendations.
-
 curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.11.2
 
 script/build


### PR DESCRIPTION
Travis builds fail due to missing the golangci-lint executable, this attempts to install that dependency and updates the golang versions to run against.