### PR TITLE
Change the type of the GetHealth API

### DIFF
--- a/cmd/vulcanizer/health.go
+++ b/cmd/vulcanizer/health.go
@@ -27,22 +27,20 @@ var cmdHealth = &cobra.Command{
 			os.Exit(1)
 		}
 
-		fmt.Println(health[0].Message)
+		fmt.Println(health.Message)
 
 		header := []string{"Cluster", "Status", "Relocating", "Initializing", "Unassigned", "Active %"}
 		rows := [][]string{}
-		for _, cluster := range health {
-			row := []string{
-				cluster.Cluster,
-				cluster.Status,
-				strconv.Itoa(cluster.RelocatingShards),
-				strconv.Itoa(cluster.InitializingShards),
-				strconv.Itoa(cluster.UnassignedShards),
-				cluster.ActiveShardsPercentage,
-			}
-
-			rows = append(rows, row)
+		row := []string{
+			health.Cluster,
+			health.Status,
+			strconv.Itoa(health.RelocatingShards),
+			strconv.Itoa(health.InitializingShards),
+			strconv.Itoa(health.UnassignedShards),
+			strconv.Itoa(health.UnassignedShards),
+			strconv.FormatFloat(health.ActiveShardsPercentage, 'f', -1, 32),
 		}
+		rows = append(rows, row)
 
 		fmt.Println(renderTable(rows, header))
 	},

--- a/es_test.go
+++ b/es_test.go
@@ -282,8 +282,8 @@ func TestGetIndices(t *testing.T) {
 func TestGetHealth(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "GET",
-		Path:     "/_cat/health",
-		Response: `[{"cluster":"elasticsearch_nickcanz","status":"yellow","relo":"0","init":"0","unassign":"5","pending_tasks":"0","active_shards_percent":"50.0%"}]`,
+		Path:     "/_cluster/health",
+		Response: `{"cluster_name":"mycluster","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":5,"active_shards":5,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0,"indices":{"unhealthyIndex":{"status":"yellow"},"healthyIndex":{"status":"green","number_of_shards":5,"number_of_replicas":0,"active_primary_shards":5,"active_shards":5,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0}}}`,
 	}
 
 	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
@@ -296,13 +296,18 @@ func TestGetHealth(t *testing.T) {
 		t.Errorf("Unexpected error expected nil, got %s", err)
 	}
 
-	if len(health) != 1 {
-		t.Errorf("Unexpected health, got %+v", health)
+	if health.ActiveShards != 5 {
+		t.Errorf("Unexpected active shards, expected 5, got %d", health.ActiveShards)
 	}
 
-	if health[0].UnassignedShards != 5 {
-		t.Errorf("Unexpected unassigned shards, expected 5, got %d", health[0].UnassignedShards)
+	if len(health.HealthyIndices) != 1 || health.HealthyIndices[0].Name != "healthyIndex" {
+		t.Errorf("Unexpected values in healthy indices, got %+v", health)
 	}
+
+	if len(health.UnhealthyIndices) != 1 || health.UnhealthyIndices[0].Name != "unhealthyIndex" {
+		t.Errorf("Unexpected values in unhealthy indices, got %+v", health)
+	}
+
 }
 
 func TestGetSettings(t *testing.T) {


### PR DESCRIPTION
GetHealth was returning an array, but that didn't really make sense as there can only be 1 return value for cluster health. It was a holdover from the way that the JSON was returning from the _cat/health endpoint.

I've changed it to use the _cluster/health API. I also added an IndexHealth struct value for holding the health information of each struct itself. This information is included in the ClusterHealth struct
via the HealthyIndices and UnhealthyIndices arrays. In the case the cluster is yellow or red, the unhealthy indices will be output in the Message field.

/cc @jessbreckenridge 