### PR TITLE
Add methods to access the _analyze API

### DIFF
--- a/cmd/vulcanizer/analyze.go
+++ b/cmd/vulcanizer/analyze.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/github/vulcanizer"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmdAnalyze.Flags().StringP("analyzer", "a", "", "The analyzer used to analyze the text Overrides field and index settings.")
+
+	cmdAnalyze.Flags().StringP("field", "", "", "Use analyzer settings of the given field to analyze against. Overridden by analyzer setting. index setting also required.")
+
+	cmdAnalyze.Flags().StringP("index", "i", "", "Specifies which index to look for field setting. Overridden by analyzer setting. field setting also required.")
+
+	cmdAnalyze.Flags().StringP("text", "t", "", "Text to analyze (required).")
+	err := cmdAnalyze.MarkFlagRequired("text")
+	if err != nil {
+		fmt.Printf("Error binding text configuration flag: %s \n", err)
+		os.Exit(1)
+	}
+
+	rootCmd.AddCommand(cmdAnalyze)
+}
+
+var cmdAnalyze = &cobra.Command{
+	Use:   "analyze",
+	Short: "Analyze text given an analyzer or a field and index.",
+	Long:  `Use Elasticsearch's analyze API to display the tokens of example text. Either "analyzer" OR "field" and "index" arguments are required.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		host, port := getConfiguration()
+		v := vulcanizer.NewClient(host, port)
+
+		text, err := cmd.Flags().GetString("text")
+		if err != nil {
+			fmt.Printf("Could not retrieve required argument: text. Error: %s\n", err)
+			os.Exit(1)
+		}
+
+		analyzer, _ := cmd.Flags().GetString("analyzer")
+
+		var tokens []vulcanizer.Token
+
+		if analyzer != "" {
+			ts, err := v.AnalyzeText(analyzer, text)
+			if err != nil {
+				fmt.Printf("Error calling analyze API: %s\n", err)
+				os.Exit(1)
+			}
+
+			tokens = ts
+		} else {
+			field, _ := cmd.Flags().GetString("field")
+			index, _ := cmd.Flags().GetString("index")
+
+			if field == "" || index == "" {
+				fmt.Println("Either `analyzer` or `field` and `index` arguments are required.")
+				os.Exit(1)
+			}
+
+			ts, err := v.AnalyzeTextWithField(index, field, text)
+			if err != nil {
+				fmt.Printf("Error calling analyze API: %s\n", err)
+				os.Exit(1)
+			}
+
+			tokens = ts
+		}
+
+		fmt.Printf("Printing tokens for the provided text: %s\n", text)
+		for _, t := range tokens {
+			fmt.Printf("\t* %s - %s\n", t.Text, t.Type)
+		}
+	},
+}

--- a/es.go
+++ b/es.go
@@ -122,6 +122,15 @@ type Repository struct {
 	Settings map[string]interface{}
 }
 
+//Holds information about the tokens that Elasticsearch analyzes
+type Token struct {
+	Text        string `json:"token"`
+	StartOffset int    `json:"start_offset"`
+	EndOffset   int    `json:"end_offset"`
+	Type        string `json:"type"`
+	Position    int    `json:"position"`
+}
+
 //Initialize a new vulcanizer client to use.
 func NewClient(host string, port int) *Client {
 	return &Client{host, port}
@@ -604,4 +613,39 @@ func (c *Client) RestoreSnapshotIndices(repository string, snapshot string, indi
 	_, err := handleErrWithBytes(agent)
 
 	return err
+}
+
+//Call the analyze API with sample text and an analyzer. https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
+//
+//Use case: You want to see how Elasticsearch will break up sample text given a specific analyzer.
+func (c *Client) AnalyzeText(analyzer, text string) ([]Token, error) {
+	request := struct {
+		Analyzer string `json:"analyzer"`
+		Text     string `json:"text"`
+	}{
+		analyzer,
+		text,
+	}
+
+	agent := c.buildPostRequest("_analyze").
+		Set("Content-Type", "application/json").
+		Send(request)
+
+	var tokenWrapper struct {
+		Tokens []Token `json:"tokens"`
+	}
+
+	err := handleErrWithStruct(agent, &tokenWrapper)
+	if err != nil {
+		return nil, err
+	}
+
+	return tokenWrapper.Tokens, nil
+}
+
+//Call the analyze API with sample text on an index and a specific field . https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
+//
+//Use case: You have a particular field that might have custom analyzers and you want to see how this field will tokenize some particular text.
+func (c *Client) AnalyzeTextWithField(index, field, text string) ([]Token, error) {
+	return nil, nil
 }

--- a/es.go
+++ b/es.go
@@ -647,5 +647,26 @@ func (c *Client) AnalyzeText(analyzer, text string) ([]Token, error) {
 //
 //Use case: You have a particular field that might have custom analyzers and you want to see how this field will tokenize some particular text.
 func (c *Client) AnalyzeTextWithField(index, field, text string) ([]Token, error) {
-	return nil, nil
+	request := struct {
+		Field string `json:"field"`
+		Text  string `json:"text"`
+	}{
+		field,
+		text,
+	}
+
+	agent := c.buildPostRequest(fmt.Sprintf("%s/_analyze", index)).
+		Set("Content-Type", "application/json").
+		Send(request)
+
+	var tokenWrapper struct {
+		Tokens []Token `json:"tokens"`
+	}
+
+	err := handleErrWithStruct(agent, &tokenWrapper)
+	if err != nil {
+		return nil, err
+	}
+
+	return tokenWrapper.Tokens, nil
 }

--- a/es_test.go
+++ b/es_test.go
@@ -962,3 +962,29 @@ func TestAnalyzeText(t *testing.T) {
 		t.Fatalf("Unexpected token type, got: %+v", tokens)
 	}
 }
+
+func TestAnalyzeTextWithField(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "POST",
+		Path:     "/myindex/_analyze",
+		Body:     `{"field":"user_email","text":"user@example.com"}`,
+		Response: `{"tokens":[{"token":"user@example.com","start_offset":0,"end_offset":16,"type":"<EMAIL>","position":1}]}`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	tokens, err := client.AnalyzeTextWithField("myindex", "user_email", "user@example.com")
+	if err != nil {
+		t.Fatalf("Got error getting analyzing text: %s", err)
+	}
+
+	if len(tokens) != 1 {
+		t.Fatalf("Got wrong number of tokens, expected 1 got %d", len(tokens))
+	}
+
+	if tokens[0].Text != "user@example.com" || tokens[0].Type != "<EMAIL>" {
+		t.Fatalf("Unexpected token got: %+v", tokens)
+	}
+}

--- a/es_test.go
+++ b/es_test.go
@@ -932,3 +932,33 @@ func TestRestoreSnapshotIndices(t *testing.T) {
 		t.Fatalf("Got error taking snapshot: %s", err)
 	}
 }
+
+func TestAnalyzeText(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "POST",
+		Path:     "/_analyze",
+		Body:     `{"analyzer":"stop","text":"This is a great test."}`,
+		Response: `{"tokens":[{"token":"great","start_offset":10,"end_offset":15,"type":"word","position":3},{"token":"test","start_offset":16,"end_offset":20,"type":"word","position":4}]}`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	tokens, err := client.AnalyzeText("stop", "This is a great test.")
+	if err != nil {
+		t.Fatalf("Got error getting analyzing text: %s", err)
+	}
+
+	if len(tokens) != 2 {
+		t.Fatalf("Got wrong number of tokens, expected 2 got %d", len(tokens))
+	}
+
+	if tokens[0].Text != "great" || tokens[1].Text != "test" {
+		t.Fatalf("Unexpected token text, got: %+v", tokens)
+	}
+
+	if tokens[0].Type != "word" || tokens[1].Type != "word" {
+		t.Fatalf("Unexpected token type, got: %+v", tokens)
+	}
+}


### PR DESCRIPTION
Elasticsearch's [_analyze API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html) can be very useful for testing tokenization, but is not the easiest API to sue.

This PR adds two new methods for accessing the _analyze API:
* `func (c *Client) AnalyzeText(analyzer, text string) ([]Token, error)` - For using an analyzer directly
* `func (c *Client) AnalyzeTextWithField(index, field, text string) ([]Token, error)` - For tokenizing given a specific field and index.

This PR adds the Token struct to hold the information from the _analyze API.

This PR adds the `vulcanizer analyze` command to use the new APIs with provided CLI program.