### PR TITLE
Add an API method to delete an index

### DIFF
--- a/es.go
+++ b/es.go
@@ -334,6 +334,25 @@ func (c *Client) GetIndices() ([]Index, error) {
 	return indices, nil
 }
 
+//Delete an index in the cluster.
+//
+//Use case: You want to remove an index and all of its data.
+func (c *Client) DeleteIndex(indexName string) error {
+	var response acknowledgedResponse
+
+	err := handleErrWithStruct(c.buildDeleteRequest(indexName), &response)
+
+	if err != nil {
+		return err
+	}
+
+	if !response.Acknowledged {
+		return fmt.Errorf(`Request to delete index "%s" was not acknowledged. %+v`, indexName, response)
+	}
+
+	return nil
+}
+
 //Get the health of the cluster.
 //
 //Use case: You want to see information needed to determine if the Elasticsearch cluster is healthy (green) or not (yellow/red).

--- a/es_test.go
+++ b/es_test.go
@@ -279,6 +279,24 @@ func TestGetIndices(t *testing.T) {
 	}
 }
 
+func TestDeleteIndex(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "DELETE",
+		Path:     "/badindex",
+		Response: `{"acknowledged": true}`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	err := client.DeleteIndex("badindex")
+
+	if err != nil {
+		t.Errorf("Unexpected error expected nil, got %s", err)
+	}
+}
+
 func TestGetHealth(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "GET",

--- a/integration_test.go
+++ b/integration_test.go
@@ -141,6 +141,20 @@ func TestSnapshots(t *testing.T) {
 	if !foundOriginalIndex || !foundRestoredIndex {
 		t.Fatalf("Couldn't find expected indices: %+v", indices)
 	}
+
+	err = c.DeleteIndex("restored_integration_test")
+	if err != nil {
+		t.Fatalf("Error deleting restored_integration_test index: %+v", indices)
+	}
+
+	indices, err = c.GetIndices()
+	if err != nil {
+		t.Fatalf("Error getting indices after index deletion: %s", err)
+	}
+
+	if len(indices) != 1 {
+		t.Fatalf("Expected 1 indices: %+v", indices)
+	}
 }
 
 func TestAllocations(t *testing.T) {


### PR DESCRIPTION
This PR adds a method to the Go API to delete an index from Elasticsearch.