### PR TITLE
Extend the `RestoreSnapshotIndices` API call with settings

### DIFF
--- a/cmd/vulcanizer/snapshot.go
+++ b/cmd/vulcanizer/snapshot.go
@@ -180,7 +180,7 @@ var cmdSnapshotRestore = &cobra.Command{
 			os.Exit(1)
 		}
 
-		err = v.RestoreSnapshotIndices(repository, snapshotName, []string{index}, prefix)
+		err = v.RestoreSnapshotIndices(repository, snapshotName, []string{index}, prefix, nil)
 		if err != nil {
 			fmt.Printf("Error while calling restore snapshot API. Error: %s\n", err)
 			os.Exit(1)

--- a/es_test.go
+++ b/es_test.go
@@ -901,7 +901,7 @@ func TestRestoreSnapshotIndices_ErrorConditions(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.Name, func(st *testing.T) {
-			err := client.RestoreSnapshotIndices(test.Repository, test.Snapshot, []string{}, "")
+			err := client.RestoreSnapshotIndices(test.Repository, test.Snapshot, []string{}, "", nil)
 
 			if err == nil && test.ExpectError {
 				st.Errorf("Expected error for test values %+v", test)
@@ -926,7 +926,31 @@ func TestRestoreSnapshotIndices(t *testing.T) {
 	defer ts.Close()
 	client := NewClient(host, port)
 
-	err := client.RestoreSnapshotIndices("backup-repo", "snapshot1", []string{"index1", "index2"}, "restored_")
+	err := client.RestoreSnapshotIndices("backup-repo", "snapshot1", []string{"index1", "index2"}, "restored_", nil)
+
+	if err != nil {
+		t.Fatalf("Got error taking snapshot: %s", err)
+	}
+}
+
+func TestRestoreSnapshotIndicesWithSettings(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "POST",
+		Path:     "/_snapshot/backup-repo/snapshot1/_restore",
+		Body:     `{"index_settings":{"index.number_of_replicas":0,"index.refresh_interval":"-1"},"indices":"index1,index2","rename_pattern":"(.+)","rename_replacement":"restored_$1"}`,
+		Response: `{"acknowledged": true }`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	indexSettings := map[string]interface{}{
+		"index.number_of_replicas": 0,
+		"index.refresh_interval":   "-1",
+	}
+
+	err := client.RestoreSnapshotIndices("backup-repo", "snapshot1", []string{"index1", "index2"}, "restored_", indexSettings)
 
 	if err != nil {
 		t.Fatalf("Got error taking snapshot: %s", err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -113,7 +113,7 @@ func TestSnapshots(t *testing.T) {
 		t.Fatalf("Unexpected snapshots, got: %+v", snapshots)
 	}
 
-	err = c.RestoreSnapshotIndices("backup-repo", "snapshot_2", []string{"integration_test"}, "restored_")
+	err = c.RestoreSnapshotIndices("backup-repo", "snapshot_2", []string{"integration_test"}, "restored_", nil)
 
 	// Let the restore complete
 	time.Sleep(5 * time.Second)


### PR DESCRIPTION
The Elasticsearch restore API supports [new index settings for restored indices](https://www.elastic.co/guide/en/elasticsearch/reference/5.5/modules-snapshots.html#_changing_index_settings_during_restore).

This is useful if you have different index settings for the restored indices such as changing the number of replica shards.