### PR TITLE
Add advanced client configuration

### DIFF
--- a/es.go
+++ b/es.go
@@ -1,6 +1,7 @@
 package vulcanizer
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,10 +20,19 @@ type ExcludeSettings struct {
 	Ips, Hosts, Names []string
 }
 
+type Auth struct {
+	User     string
+	Password string
+}
+
 //Hold connection information to a Elasticsearch cluster.
 type Client struct {
-	Host string
-	Port int
+	Host      string
+	Port      int
+	Secure    bool
+	TLSConfig *tls.Config
+	Timeout   time.Duration
+	*Auth
 }
 
 //Holds information about an Elasticsearch node, based on the _cat/nodes API: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-nodes.html
@@ -133,7 +143,7 @@ type Token struct {
 
 //Initialize a new vulcanizer client to use.
 func NewClient(host string, port int) *Client {
-	return &Client{host, port}
+	return &Client{Host: host, Port: port}
 }
 
 const clusterSettingsPath = "_cluster/settings"
@@ -196,20 +206,50 @@ func handleErrWithStruct(s *gorequest.SuperAgent, v interface{}) error {
 	return nil
 }
 
+func (c *Client) getAgent(method, path string) *gorequest.SuperAgent {
+	agent := gorequest.New().Set("Accept", "application/json")
+	agent.Method = method
+
+	var protocol string
+	if c.Secure {
+		protocol = "https"
+	} else {
+		protocol = "http"
+	}
+
+	agent.Url = fmt.Sprintf("%s://%s:%v/%s", protocol, c.Host, c.Port, path)
+
+	if c.Auth != nil {
+		agent.SetBasicAuth(c.Auth.User, c.Auth.Password)
+	}
+
+	if c.TLSConfig != nil {
+		agent.TLSClientConfig(c.TLSConfig)
+	}
+
+	if c.Timeout != 0 {
+		agent.Timeout(c.Timeout)
+	} else {
+		agent.Timeout(1 * time.Minute)
+	}
+
+	return agent
+}
+
 func (c *Client) buildGetRequest(path string) *gorequest.SuperAgent {
-	return gorequest.New().Get(fmt.Sprintf("http://%s:%v/%s", c.Host, c.Port, path)).Set("Accept", "application/json")
+	return c.getAgent(gorequest.GET, path)
 }
 
 func (c *Client) buildPutRequest(path string) *gorequest.SuperAgent {
-	return gorequest.New().Put(fmt.Sprintf("http://%s:%v/%s", c.Host, c.Port, path))
+	return c.getAgent(gorequest.PUT, path)
 }
 
 func (c *Client) buildDeleteRequest(path string) *gorequest.SuperAgent {
-	return gorequest.New().Delete(fmt.Sprintf("http://%s:%v/%s", c.Host, c.Port, path))
+	return c.getAgent(gorequest.DELETE, path)
 }
 
 func (c *Client) buildPostRequest(path string) *gorequest.SuperAgent {
-	return gorequest.New().Post(fmt.Sprintf("http://%s:%v/%s", c.Host, c.Port, path))
+	return c.getAgent(gorequest.POST, path)
 }
 
 // Get current cluster settings for shard allocation exclusion rules.

--- a/es_test.go
+++ b/es_test.go
@@ -1,6 +1,7 @@
 package vulcanizer
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -16,12 +17,8 @@ type ServerSetup struct {
 	HTTPStatus                   int
 }
 
-// setupTestServer sets up an HTTP test server to serve data to the test that come after it.
-
-func setupTestServers(t *testing.T, setups []*ServerSetup) (string, int, *httptest.Server) {
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
+func buildTestServer(t *testing.T, setups []*ServerSetup, tls bool) *httptest.Server {
+	handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestBytes, _ := ioutil.ReadAll(r.Body)
 		requestBody := string(requestBytes)
 
@@ -44,7 +41,33 @@ func setupTestServers(t *testing.T, setups []*ServerSetup) (string, int, *httpte
 		if !matched {
 			t.Fatalf("No requests matched setup. Got method %s, Path %s, body %s", r.Method, r.URL.EscapedPath(), requestBody)
 		}
-	}))
+	})
+
+	var ts *httptest.Server
+
+	if tls {
+		ts = httptest.NewTLSServer(handlerFunc)
+	} else {
+		ts = httptest.NewServer(handlerFunc)
+	}
+
+	return ts
+}
+
+// setupTestServer sets up an HTTP test server to serve data to the test that come after it.
+func setupTestServers(t *testing.T, setups []*ServerSetup) (string, int, *httptest.Server) {
+
+	ts := buildTestServer(t, setups, false)
+
+	url, _ := url.Parse(ts.URL)
+	port, _ := strconv.Atoi(url.Port())
+	return url.Hostname(), port, ts
+}
+
+func setupTestTLSServers(t *testing.T, setups []*ServerSetup) (string, int, *httptest.Server) {
+
+	ts := buildTestServer(t, setups, true)
+
 	url, _ := url.Parse(ts.URL)
 	port, _ := strconv.Atoi(url.Port())
 	return url.Hostname(), port, ts
@@ -289,6 +312,38 @@ func TestGetHealth(t *testing.T) {
 	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
 	defer ts.Close()
 	client := NewClient(host, port)
+
+	health, err := client.GetHealth()
+
+	if err != nil {
+		t.Errorf("Unexpected error expected nil, got %s", err)
+	}
+
+	if health.ActiveShards != 5 {
+		t.Errorf("Unexpected active shards, expected 5, got %d", health.ActiveShards)
+	}
+
+	if len(health.HealthyIndices) != 1 || health.HealthyIndices[0].Name != "healthyIndex" {
+		t.Errorf("Unexpected values in healthy indices, got %+v", health)
+	}
+
+	if len(health.UnhealthyIndices) != 1 || health.UnhealthyIndices[0].Name != "unhealthyIndex" {
+		t.Errorf("Unexpected values in unhealthy indices, got %+v", health)
+	}
+}
+
+func TestGetHealth_TLS(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "GET",
+		Path:     "/_cluster/health",
+		Response: `{"cluster_name":"mycluster","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":5,"active_shards":5,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0,"indices":{"unhealthyIndex":{"status":"yellow"},"healthyIndex":{"status":"green","number_of_shards":5,"number_of_replicas":0,"active_primary_shards":5,"active_shards":5,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0}}}`,
+	}
+
+	host, port, ts := setupTestTLSServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+	client.Secure = true
+	client.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 
 	health, err := client.GetHealth()
 


### PR DESCRIPTION
This PR extends the `vulcanizer.Client` struct to contain additional properties that are helpful in certain situations.

### New Properties

* `Timeout` - defaults to 1 minute, but you can set your own value
* `Secure` - boolean to expect TLS connections
* `TLSConfig` - Expose the existing Go [crypto/tls Config](https://golang.org/pkg/crypto/tls/#Config) for complex situations such as client certificates or ignoring certificate validation (let's not re-invent the wheel)
* `Auth` - for setting HTTP Basic authentication

/cc @jessbreckenridge for review