### PR TITLE
Add an API method to show pretty printed index mappings

### DIFF
--- a/es.go
+++ b/es.go
@@ -805,3 +805,22 @@ func (c *Client) SetIndexSetting(index, setting, value string) (string, string, 
 
 	return currentValue, value, nil
 }
+
+//Get the mappings of an index in a pretty-printed format.
+//
+//Use case: You can view the custom mappings that are set on a particular index.
+func (c *Client) GetPrettyIndexMappings(index string) (string, error) {
+	body, err := handleErrWithBytes(c.buildGetRequest(fmt.Sprintf("%s/_mappings", index)))
+
+	if err != nil {
+		return "", err
+	}
+
+	var prettyPrinted bytes.Buffer
+	err = json.Indent(&prettyPrinted, body, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return prettyPrinted.String(), nil
+}

--- a/es_test.go
+++ b/es_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -1171,5 +1172,32 @@ func TestSetIndexSetting(t *testing.T) {
 
 	if current != "2" {
 		t.Errorf("Unexpected current setting value, expected 2, got %s", current)
+	}
+}
+
+func TestGetPrettyIndexMappings(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "GET",
+		Path:     "/octocat/_mappings",
+		Response: `{"octocat":{"mappings":{"doc":{"properties":{"created_at":{"type":"date"}}}}}}`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	mappings, err := client.GetPrettyIndexMappings("octocat")
+
+	if err != nil {
+		t.Errorf("Unexpected error, got %s", err)
+	}
+
+	if mappings == "" {
+		t.Error("Unexpected index mappings, got empty string")
+	}
+
+	lineCount := strings.Count(mappings, "\n")
+	if lineCount != 12 {
+		t.Errorf("Unexpected line count on mappings, expected 12, got %d", lineCount)
 	}
 }


### PR DESCRIPTION
This PR adds a new method to display the mappings of an index.