### PR TITLE
Add additional integration tests 

### DIFF
--- a/integration_data/v5/elasticsearch.dockerfile
+++ b/integration_data/v5/elasticsearch.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.13
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.15
 
 USER root
 

--- a/integration_data/v6/elasticsearch.dockerfile
+++ b/integration_data/v6/elasticsearch.dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.6.1
 
 USER root
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -39,6 +39,36 @@ func TestIndices(t *testing.T) {
 	if indices[0].DocumentCount != 10 {
 		t.Fatalf("Expected 10 docs, got: %v", indices[0].DocumentCount)
 	}
+
+	if indices[0].ReplicaCount != 1 {
+		t.Fatalf("Expected replica count of 1, got: %v", indices[0].ReplicaCount)
+	}
+
+	_, _, err = c.SetIndexSetting(indices[0].Name, "number_of_replicas", "2")
+	if err != nil {
+		t.Fatalf("Error setting index number_of_replicas: %s", err)
+	}
+
+	indexSettings, err := c.GetIndexSettings(indices[0].Name)
+	if err != nil {
+		t.Fatalf("Error getting index settings: %s", err)
+	}
+
+	for i := range indexSettings {
+		setting := indexSettings[i]
+		if setting.Setting == "number_of_replicas" && setting.Value != "2" {
+			t.Fatalf("Expected replica count of 2, got: %v", setting)
+		}
+	}
+
+	indices, err = c.GetIndices()
+	if err != nil {
+		t.Fatalf("Error getting indices: %s", err)
+	}
+
+	if indices[0].ReplicaCount != 2 {
+		t.Fatalf("Expected replica count of 2, got: %v", indices[0].ReplicaCount)
+	}
 }
 
 func TestVerifyRepository(t *testing.T) {


### PR DESCRIPTION
This PR adds additional integration test coverage of some new endpoints and updates our integration tests to run against the latest minor release versions of Elasticsearch.

/cc @jessbreckenridge 