### PR TITLE
adding support for elasticsearch domains behind loadbalancers

### DIFF
--- a/es.go
+++ b/es.go
@@ -220,7 +220,12 @@ func (c *Client) getAgent(method, path string) *gorequest.SuperAgent {
 		protocol = "http"
 	}
 
-	agent.Url = fmt.Sprintf("%s://%s:%v/%s", protocol, c.Host, c.Port, path)
+	if c.Port > 0 {
+		agent.Url = fmt.Sprintf("%s://%s:%v/%s", protocol, c.Host, c.Port, path)
+	} else {
+		agent.Url = fmt.Sprintf("%s://%s/%s", protocol, c.Host, path)
+	}
+
 
 	if c.Auth != nil {
 		agent.SetBasicAuth(c.Auth.User, c.Auth.Password)


### PR DESCRIPTION
- If no port is specified or port is equal to 0, exclude port from requests (assume elasticsearch domain is behind loadbalancer).