### PR TITLE
Fix typo in cmd long description

### DIFF
--- a/cmd/vulcanizer/health.go
+++ b/cmd/vulcanizer/health.go
@@ -16,7 +16,7 @@ func init() {
 var cmdHealth = &cobra.Command{
 	Use:   "health",
 	Short: "Display the health of the cluster.",
-	Long:  `Get detailed information about what consitutes the health of the cluster`,
+	Long:  `Get detailed information about what constitutes the health of the cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
 		host, port := getConfiguration()
 		v := vulcanizer.NewClient(host, port)

--- a/cmd/vulcanizer/indices.go
+++ b/cmd/vulcanizer/indices.go
@@ -16,7 +16,7 @@ func init() {
 var cmdIndices = &cobra.Command{
 	Use:   "indices",
 	Short: "Display the indices of the cluster.",
-	Long:  `Show what indices are created on the give cluster.`,
+	Long:  `Show what indices are created on the given cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		host, port := getConfiguration()
 		v := vulcanizer.NewClient(host, port)

--- a/cmd/vulcanizer/settings.go
+++ b/cmd/vulcanizer/settings.go
@@ -37,7 +37,7 @@ func printSettings(settings []vulcanizer.Setting, name string) {
 var cmdSettings = &cobra.Command{
 	Use:   "settings",
 	Short: "Display all the settings of the cluster.",
-	Long:  `This command displays all the transient and persisent settings that have been set on the given cluster.`,
+	Long:  `This command displays all the transient and persistent settings that have been set on the given cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		host, port := getConfiguration()
 		v := vulcanizer.NewClient(host, port)


### PR DESCRIPTION
Hello,
this pull request fix few typo in the command long description