### PR TITLE
Add get shards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 tmp/*
 .vscode/settings.json
+.idea

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Available Commands:
   repository  Interact with the configured snapshot repositories.
   setting     Interact with cluster settings.
   settings    Display all the settings of the cluster.
+  shards      Get shard data by cluster node(s).
   snapshot    Interact with a specific snapshot.
 
 Flags:

--- a/cmd/vulcanizer/shards.go
+++ b/cmd/vulcanizer/shards.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"github.com/github/vulcanizer"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var nodesToCheck []string
+
+func init() {
+	cmdShards.Flags().StringSliceVarP(&nodesToCheck, "nodes", "n", []string{}, "Elasticsearch node(s) to get shard information from")
+	rootCmd.AddCommand(cmdShards)
+}
+
+var cmdShards = &cobra.Command{
+	Use:   "shards",
+	Short: "Get shard data by cluster node(s).",
+	Long:  `This command gets shard related data by node from the cluster.  Default is to return all shards.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		host, port := getConfiguration()
+		v := vulcanizer.NewClient(host, port)
+		shards, err := v.GetShards(nodesToCheck)
+
+		if err != nil {
+			fmt.Printf("Error retrieving shard information: %s \n", err)
+			os.Exit(1)
+		}
+
+		header := []string{"Index", "Shard", "Type", "State", "Docs", "Store", "IP", "Node"}
+		rows := [][]string{}
+
+		for _, shard := range shards {
+			row := []string{
+				shard.Index,
+				shard.Shard,
+				shard.Type,
+				shard.State,
+				shard.Docs,
+				shard.Store,
+				shard.IP,
+				shard.Node,
+			}
+			rows = append(rows, row)
+		}
+
+		table := renderTable(rows, header)
+		fmt.Println(table)
+	},
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -210,3 +210,40 @@ func TestAllocations(t *testing.T) {
 		t.Fatalf("Expected allocation to be all, got %s", val)
 	}
 }
+
+func TestGetShards_AllNodes(t *testing.T) {
+	c := vulcanizer.NewClient("localhost", 49200)
+
+	val, err := c.GetShards(nil)
+
+	if err != nil {
+		t.Fatalf("Error fetching shards: %s", err)
+	}
+
+	if val == nil {
+		t.Fatal("Expected a slice of Shard, got nil instead")
+	}
+
+	// Account for the unassigned replicas
+	if len(val) != 15 {
+		t.Fatalf("Expected 15 shards, got %d instead", len(val))
+	}
+}
+
+func TestGetShards_Regexp(t *testing.T) {
+	c := vulcanizer.NewClient("localhost", 49200)
+
+	val, err := c.GetShards([]string{"vulcanizer-elasticsearch-v(\\d|\\d-\\d)"})
+
+	if err != nil {
+		t.Fatalf("Error fetching shards: %s", err)
+	}
+
+	if val == nil {
+		t.Fatal("Expected a slice of Shard, got nil instead")
+	}
+
+	if len(val) != 10 {
+		t.Fatalf("Expected 15 shards, got %d instead", len(val))
+	}
+}


### PR DESCRIPTION
This PR adds the `shards` command to vulcanizer for pulling shard data on all nodes, or comma delimited list of nodes via --nodes flag.