### PR TITLE
List aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Usage:
   vulcanizer [command]
 
 Available Commands:
+  aliases     Interact with aliases of the cluster.
   allocation  Set shard allocation on the cluster.
   drain       Drain a server or see what servers are draining.
   fill        Fill servers with data, removing shard allocation exclusion rules.

--- a/cmd/vulcanizer/aliases.go
+++ b/cmd/vulcanizer/aliases.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/github/vulcanizer"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	setupAliasesListSubCommand()
+	rootCmd.AddCommand(cmdAliases)
+}
+
+func setupAliasesListSubCommand() {
+	cmdAliases.AddCommand(cmdAliasesList)
+}
+
+var cmdAliases = &cobra.Command{
+	Use:   "aliases",
+	Short: "Interact with aliases of the cluster.",
+	Long:  `Use the list subcommand.`,
+}
+
+var cmdAliasesList = &cobra.Command{
+	Use:   "list",
+	Short: "Display the aliases of the cluster",
+	Long:  `Show what aliases are created on the given cluster.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		host, port, auth := getConfiguration()
+		v := vulcanizer.NewClient(host, port)
+		v.Auth = auth
+		aliases, err := v.GetAliases()
+
+		if err != nil {
+			fmt.Printf("Error getting aliases: %s\n", err)
+			os.Exit(1)
+		}
+
+		header := []string{"Alias", "Index", "Filter", "routing.index", "routing.search"}
+		rows := [][]string{}
+
+		for _, alias := range aliases {
+			row := []string{
+				alias.Name,
+				alias.IndexName,
+				alias.Filter,
+				alias.RoutingIndex,
+				alias.RoutingSearch,
+			}
+
+			rows = append(rows, row)
+		}
+
+		table := renderTable(rows, header)
+		fmt.Println(table)
+	},
+}

--- a/es.go
+++ b/es.go
@@ -71,6 +71,15 @@ type Shard struct {
 	Node  string `json:"node"`
 }
 
+// Holds information about an Elasticsearch alias, based on the _cat/aliases API: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-alias.html
+type Alias struct {
+	Name          string `json:"alias"`
+	IndexName     string `json:"index"`
+	Filter        string `json:"filter"`
+	RoutingIndex  string `json:"routing.index"`
+	RoutingSearch string `json:"routing.search"`
+}
+
 //Holds information about the health of an Elasticsearch cluster, based on the cluster health API: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cluster-health.html
 type ClusterHealth struct {
 	Cluster                string  `json:"cluster_name"`
@@ -395,6 +404,21 @@ func (c *Client) GetIndices() ([]Index, error) {
 	}
 
 	return indices, nil
+}
+
+//Get all the aliases in the cluster.
+//
+//Use case: You want to see some basic info on all the aliases of the cluster
+func (c *Client) GetAliases() ([]Alias, error) {
+	var aliases []Alias
+
+	err := handleErrWithStruct(c.buildGetRequest("_cat/aliases?h=alias,index,filter,routing.index,routing.search"), &aliases)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return aliases, nil
 }
 
 //Delete an index in the cluster.

--- a/es_test.go
+++ b/es_test.go
@@ -303,6 +303,36 @@ func TestGetIndices(t *testing.T) {
 	}
 }
 
+func TestGetAliases(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "GET",
+		Path:     "/_cat/aliases",
+		Response: `[{"alias": "test","index": "test_v1","filter": "-filter","routing.index": "-routing.index","routing.search": "-routing.search"},{"alias": "test_again","index": "test_again_v1","filter": "--filter","routing.index": "--routing.index","routing.search": "--routing.search"}]`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	aliases, err := client.GetAliases()
+
+	if err != nil {
+		t.Errorf("Unexpected error expected nil, got %s", err)
+	}
+
+	if len(aliases) != 2 {
+		t.Errorf("Unexpected aliases, got %v", aliases)
+	}
+
+	if aliases[0].Name != "test" || aliases[0].IndexName != "test_v1" || aliases[0].Filter != "-filter" || aliases[0].RoutingIndex != "-routing.index" || aliases[0].RoutingSearch != "-routing.search" {
+		t.Errorf("Unexpected index values, got %v", aliases[0])
+	}
+
+	if aliases[1].Name != "test_again" || aliases[1].IndexName != "test_again_v1" || aliases[1].Filter != "--filter" || aliases[1].RoutingIndex != "--routing.index" || aliases[1].RoutingSearch != "--routing.search" {
+		t.Errorf("Unexpected index values, got %v", aliases[1])
+	}
+}
+
 func TestDeleteIndex(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "DELETE",

--- a/integration_test.go
+++ b/integration_test.go
@@ -71,6 +71,28 @@ func TestIndices(t *testing.T) {
 	}
 }
 
+func TestAliases(t *testing.T) {
+	c := vulcanizer.NewClient("localhost", 49200)
+
+	aliases, err := c.GetAliases()
+
+	if err != nil {
+		t.Fatalf("Error getting aliases: %s", err)
+	}
+
+	if len(aliases) != 1 {
+		t.Fatalf("Expected 1 index, got: %v", len(aliases))
+	}
+
+	if aliases[0].Name != "integration_test_alias" {
+		t.Fatalf("Expected aliases with name integration_test_alias, got: %v", aliases[0].Name)
+	}
+
+	if aliases[0].IndexName != "integration_test" {
+		t.Fatalf("Expected index name integration_test, got: %v", aliases[0].IndexName)
+	}
+}
+
 func TestVerifyRepository(t *testing.T) {
 	c := vulcanizer.NewClient("localhost", 49200)
 

--- a/script/integration-test
+++ b/script/integration-test
@@ -21,6 +21,7 @@ done
 curl -s -H "Content-Type: application/x-ndjson" -XPOST localhost:49200/_bulk --data-binary "@../documents.dat"; echo
 curl -s -XPUT localhost:49200/_snapshot/backup-repo -d '{ "type": "fs", "settings": { "location": "/backups" } }'
 curl -s -XPUT localhost:49200/_snapshot/backup-repo/snapshot_1?wait_for_completion=true
+curl -s -H "Content-Type: application/json" XPOST localhost:49200/_aliases -d '{ "actions" : [ { "add" : { "index" : "integration_test", "alias" : "integration_test_alias" } } ] }'
 
 # Run tests
 go test -v github.com/github/vulcanizer/... -tags integration -count=1
@@ -41,6 +42,7 @@ done
 curl -s -H "Content-Type: application/x-ndjson" -XPOST localhost:49200/_bulk --data-binary "@../documents.dat"; echo
 curl -s -XPUT -H 'Content-Type: application/json' localhost:49200/_snapshot/backup-repo -d '{ "type": "fs", "settings": { "location": "/backups" } }'
 curl -s -XPUT localhost:49200/_snapshot/backup-repo/snapshot_1?wait_for_completion=true
+curl -s -H "Content-Type: application/json" XPOST localhost:49200/_aliases -d '{ "actions" : [ { "add" : { "index" : "integration_test", "alias" : "integration_test_alias" } } ] }'
 
 # Run tests
 go test -v github.com/github/vulcanizer/... -tags integration -count=1


### PR DESCRIPTION
This PR adds `aliases`.

For example: `vulcanizer alias list`.
I chose this instead of `vulcanizer alias` because  I am planning on adding support to add/remove aliases soon.