### PR TITLE
PR to fix issue #41 with panics on typechecking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: go
 go:
     - "1.10.x"
     - "1.11.x"
+    - "1.12.x"
 
 services:
     - docker
@@ -13,7 +14,7 @@ os:
 install: true
 
 before_script:
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.11.2
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.15.0
 
 script: script/integration-test
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -16,7 +16,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
   go get -u github.com/rakyll/gotest
 fi
 
-# Install linter. Should be universal. Version is pinned per package reccomendations.
-curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.11.2
+# Install linter. Should be universal. Version is pinned per package recommendations.
+curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.15.0
 
 script/build


### PR DESCRIPTION
This PR is to close issue #41 by upgrading golangci-lint to 1.15.0.  It also adds go version 1.12.x to the travis tests.