### PR TITLE
add/delete/update cluster aliases

### DIFF
--- a/cmd/vulcanizer/aliases.go
+++ b/cmd/vulcanizer/aliases.go
@@ -10,11 +10,75 @@ import (
 
 func init() {
 	setupAliasesListSubCommand()
+	setupAliasesUpdateSubCommand()
+	setupAliasesAddSubCommand()
+	setupAliasesDeleteSubCommand()
 	rootCmd.AddCommand(cmdAliases)
 }
 
 func setupAliasesListSubCommand() {
 	cmdAliases.AddCommand(cmdAliasesList)
+}
+
+func setupAliasesUpdateSubCommand() {
+	cmdAliasesUpdate.Flags().StringP("index", "i", "", "Index from which to delete the alias (required)")
+	err := cmdAliasesUpdate.MarkFlagRequired("index")
+	if err != nil {
+		fmt.Printf("Error binding index flag: %s \n", err)
+		os.Exit(1)
+	}
+
+	cmdAliasesUpdate.Flags().StringP("old-alias", "", "", "Alias to be deleted from the specified index (required)")
+	err = cmdAliasesUpdate.MarkFlagRequired("old-alias")
+	if err != nil {
+		fmt.Printf("Error binding old-alias flag: %s \n", err)
+		os.Exit(1)
+	}
+
+	cmdAliasesUpdate.Flags().StringP("new-alias", "", "", "Alias to be added to the specified index (required)")
+	err = cmdAliasesUpdate.MarkFlagRequired("new-alias")
+	if err != nil {
+		fmt.Printf("Error binding new-alias flag: %s \n", err)
+		os.Exit(1)
+	}
+
+	cmdAliases.AddCommand(cmdAliasesUpdate)
+}
+
+func setupAliasesAddSubCommand() {
+	cmdAliasesAdd.Flags().StringP("index", "i", "", "Index to which the alias should be added (required)")
+	err := cmdAliasesAdd.MarkFlagRequired("index")
+	if err != nil {
+		fmt.Printf("Error binding index flag: %s \n", err)
+		os.Exit(1)
+	}
+
+	cmdAliasesAdd.Flags().StringP("alias", "a", "", "Alias to be added from the specified index (required)")
+	err = cmdAliasesAdd.MarkFlagRequired("alias")
+	if err != nil {
+		fmt.Printf("Error binding alias flag: %s \n", err)
+		os.Exit(1)
+	}
+
+	cmdAliases.AddCommand(cmdAliasesAdd)
+}
+
+func setupAliasesDeleteSubCommand() {
+	cmdAliasesDelete.Flags().StringP("index", "i", "", "Index from which the alias should be deleted (required)")
+	err := cmdAliasesDelete.MarkFlagRequired("index")
+	if err != nil {
+		fmt.Printf("Error binding index flag: %s \n", err)
+		os.Exit(1)
+	}
+
+	cmdAliasesDelete.Flags().StringP("alias", "a", "", "Alias to be deleted to the specified index (required)")
+	err = cmdAliasesDelete.MarkFlagRequired("alias")
+	if err != nil {
+		fmt.Printf("Error binding alias flag: %s \n", err)
+		os.Exit(1)
+	}
+
+	cmdAliases.AddCommand(cmdAliasesDelete)
 }
 
 var cmdAliases = &cobra.Command{
@@ -55,5 +119,127 @@ var cmdAliasesList = &cobra.Command{
 
 		table := renderTable(rows, header)
 		fmt.Println(table)
+	},
+}
+
+var cmdAliasesUpdate = &cobra.Command{
+	Use:   "update",
+	Short: "Update an index's alias",
+	Long:  `In one atomic operation delete an existing alias and create a new one for a given index on the given cluster.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		host, port, auth := getConfiguration()
+		v := vulcanizer.NewClient(host, port)
+		v.Auth = auth
+
+		indexName, err := cmd.Flags().GetString("index")
+		if err != nil {
+			fmt.Printf("Could not retrieve required argument: index. Error: %s\n", err)
+			os.Exit(1)
+		}
+
+		newAlias, err := cmd.Flags().GetString("new-alias")
+		if err != nil {
+			fmt.Printf("Could not retrieve required argument: new-alias. Error: %s\n", err)
+			os.Exit(1)
+		}
+
+		oldAlias, err := cmd.Flags().GetString("old-alias")
+		if err != nil {
+			fmt.Printf("Could not retrieve required argument: old-alias. Error: %s\n", err)
+			os.Exit(1)
+		}
+
+		actions := []vulcanizer.AliasAction{
+			{
+				ActionType: vulcanizer.AddAlias,
+				IndexName:  indexName,
+				AliasName:  newAlias,
+			},
+			{
+				ActionType: vulcanizer.RemoveAlias,
+				IndexName:  indexName,
+				AliasName:  oldAlias,
+			},
+		}
+
+		err = v.ModifyAliases(actions)
+		if err != nil {
+			fmt.Printf("Error while taking snapshot. Error: %s\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var cmdAliasesAdd = &cobra.Command{
+	Use:   "add",
+	Short: "Add an alias",
+	Long:  `Add a new alias to a given index in the given cluster.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		host, port, auth := getConfiguration()
+		v := vulcanizer.NewClient(host, port)
+		v.Auth = auth
+
+		indexName, err := cmd.Flags().GetString("index")
+		if err != nil {
+			fmt.Printf("Could not retrieve required argument: index. Error: %s\n", err)
+			os.Exit(1)
+		}
+
+		aliasName, err := cmd.Flags().GetString("alias")
+		if err != nil {
+			fmt.Printf("Could not retrieve required argument: alias. Error: %s\n", err)
+			os.Exit(1)
+		}
+
+		actions := []vulcanizer.AliasAction{
+			{
+				ActionType: vulcanizer.AddAlias,
+				IndexName:  indexName,
+				AliasName:  aliasName,
+			},
+		}
+
+		err = v.ModifyAliases(actions)
+		if err != nil {
+			fmt.Printf("Error while taking adding a new alias. Error: %s\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var cmdAliasesDelete = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete an alias",
+	Long:  `Delete an alias associated to a given index in the given cluster.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		host, port, auth := getConfiguration()
+		v := vulcanizer.NewClient(host, port)
+		v.Auth = auth
+
+		indexName, err := cmd.Flags().GetString("index")
+		if err != nil || indexName == "" {
+			fmt.Printf("Could not retrieve required argument: index. Error: %s\n", err)
+			os.Exit(1)
+		}
+
+		aliasName, err := cmd.Flags().GetString("alias")
+		if err != nil {
+			fmt.Printf("Could not retrieve required argument: alias. Error: %s\n", err)
+			os.Exit(1)
+		}
+
+		actions := []vulcanizer.AliasAction{
+			{
+				ActionType: vulcanizer.RemoveAlias,
+				IndexName:  indexName,
+				AliasName:  aliasName,
+			},
+		}
+
+		err = v.ModifyAliases(actions)
+		if err != nil {
+			fmt.Printf("Error while deleting the alias. Error: %s\n", err)
+			os.Exit(1)
+		}
 	},
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -92,6 +92,103 @@ func TestAliases(t *testing.T) {
 	}
 }
 
+func TestAliasesAddDeleteUpdate(t *testing.T) {
+	c := vulcanizer.NewClient("localhost", 49200)
+
+	t.Run("update index alias", func(t *testing.T) {
+		actions := []vulcanizer.AliasAction{
+			{
+				ActionType: vulcanizer.AddAlias,
+				IndexName:  "integration_test",
+				AliasName:  "integration_test_new_alias",
+			},
+			{
+				ActionType: vulcanizer.RemoveAlias,
+				IndexName:  "integration_test",
+				AliasName:  "integration_test_alias",
+			},
+		}
+
+		err := c.ModifyAliases(actions)
+		if err != nil {
+			t.Fatalf("Error modifying aliases: %s", err)
+		}
+
+		aliases, err := c.GetAliases()
+		if err != nil {
+			t.Fatalf("Error getting aliases: %s", err)
+		}
+
+		if len(aliases) != 1 {
+			t.Fatalf("Expected 1 index, got: %v", len(aliases))
+		}
+
+		if aliases[0].Name != "integration_test_new_alias" {
+			t.Fatalf("Expected aliases with name integration_test_alias, got: %v", aliases[0].Name)
+		}
+
+		if aliases[0].IndexName != "integration_test" {
+			t.Fatalf("Expected indes name integration_test, got: %v", aliases[0].IndexName)
+		}
+	})
+
+	t.Run("delete index alias", func(t *testing.T) {
+		actions := []vulcanizer.AliasAction{
+			{
+				ActionType: vulcanizer.RemoveAlias,
+				IndexName:  "integration_test",
+				AliasName:  "integration_test_new_alias",
+			},
+		}
+
+		err := c.ModifyAliases(actions)
+		if err != nil {
+			t.Fatalf("Error modifying aliases: %s", err)
+		}
+
+		aliases, err := c.GetAliases()
+		if err != nil {
+			t.Fatalf("Error getting aliases: %s", err)
+		}
+
+		if len(aliases) != 0 {
+			t.Fatalf("Expected 0 index, got: %v", len(aliases))
+		}
+	})
+
+	t.Run("add new index alias", func(t *testing.T) {
+		actions := []vulcanizer.AliasAction{
+			{
+				ActionType: vulcanizer.AddAlias,
+				IndexName:  "integration_test",
+				AliasName:  "integration_test_new_alias_again",
+			},
+		}
+
+		err := c.ModifyAliases(actions)
+		if err != nil {
+			t.Fatalf("Error modifying aliases: %s", err)
+		}
+
+		aliases, err := c.GetAliases()
+		if err != nil {
+			t.Fatalf("Error getting aliases: %s", err)
+		}
+
+		if len(aliases) != 1 {
+			t.Fatalf("Expected 1 index, got: %v", len(aliases))
+		}
+
+		if aliases[0].Name != "integration_test_new_alias_again" {
+			t.Fatalf("Expected aliases with name integration_test_new_alias_again, got: %v", aliases[0].Name)
+		}
+
+		if aliases[0].IndexName != "integration_test" {
+			t.Fatalf("Expected indes name integration_test, got: %v", aliases[0].IndexName)
+		}
+	})
+}
+
 func TestVerifyRepository(t *testing.T) {
 	c := vulcanizer.NewClient("localhost", 49200)
 


### PR DESCRIPTION
This PR adds support for the following operations in the library and the CLI:
- Adding an alias
- Deleting an alias
- Updating an alias in one atomic operation

Here is how the CLI will work with this implementation:
```go
$ vulcanizer aliases add -i integration_test -a integration_test_alias

$ vulcanizer aliases update -i integration_test --old-alias integration_test_alias --new-alias integration_test_new_alias

$ vulcanizer aliases delete -i integration_test -a integration_test_new_alias
```

Please let me know if you have any suggestions to improve the API, the implementation or functions/variable names. 