### PR TITLE
Refactor `GetShards` command

### DIFF
--- a/es_test.go
+++ b/es_test.go
@@ -18,7 +18,7 @@ type ServerSetup struct {
 	HTTPStatus                   int
 }
 
-func buildTestServer(t *testing.T, setups []*ServerSetup, tls bool) *httptest.Server {
+func buildTestServer(t testing.TB, setups []*ServerSetup, tls bool) *httptest.Server {
 	handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestBytes, _ := ioutil.ReadAll(r.Body)
 		requestBody := string(requestBytes)
@@ -56,7 +56,7 @@ func buildTestServer(t *testing.T, setups []*ServerSetup, tls bool) *httptest.Se
 }
 
 // setupTestServer sets up an HTTP test server to serve data to the test that come after it.
-func setupTestServers(t *testing.T, setups []*ServerSetup) (string, int, *httptest.Server) {
+func setupTestServers(t testing.TB, setups []*ServerSetup) (string, int, *httptest.Server) {
 
 	ts := buildTestServer(t, setups, false)
 
@@ -65,7 +65,7 @@ func setupTestServers(t *testing.T, setups []*ServerSetup) (string, int, *httpte
 	return url.Hostname(), port, ts
 }
 
-func setupTestTLSServers(t *testing.T, setups []*ServerSetup) (string, int, *httptest.Server) {
+func setupTestTLSServers(t testing.TB, setups []*ServerSetup) (string, int, *httptest.Server) {
 
 	ts := buildTestServer(t, setups, true)
 
@@ -1324,5 +1324,122 @@ func TestGetShards_NoNodes(t *testing.T) {
 	if len(shards) != 2 {
 		t.Errorf("Expected slice of 2 shards, got %d instead", len(shards))
 	}
+}
 
+func benchmarkShardSetup(numShards int) *ServerSetup {
+	setup := ServerSetup{
+		Method: "GET",
+		Path:   "/_cat/shards",
+	}
+
+	var largeShardList []string
+	shard := `{"index":"example_index","shard":"1","prirep":"p","state":"STARTED","docs":"0","store":"162b","ip":"172.16.27.16","node":"search-storage-abc123"}`
+	for n := 0; n < numShards; n++ {
+		largeShardList = append(largeShardList, shard)
+	}
+
+	setup.Response = fmt.Sprintf("[%s]", strings.Join(largeShardList, ","))
+
+	return &setup
+}
+
+var resultShards []Shard
+
+func BenchmarkShards_NoNodes_100Shards(b *testing.B) {
+	host, port, ts := setupTestServers(b, []*ServerSetup{benchmarkShardSetup(100)})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	var shards []Shard
+
+	for n := 0; n < b.N; n++ {
+		shards, _ = client.GetShards(nil)
+	}
+
+	resultShards = shards
+}
+
+func BenchmarkShards_NoNodes_1kShards(b *testing.B) {
+	host, port, ts := setupTestServers(b, []*ServerSetup{benchmarkShardSetup(1000)})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	var shards []Shard
+
+	for n := 0; n < b.N; n++ {
+		shards, _ = client.GetShards(nil)
+	}
+
+	resultShards = shards
+}
+
+func BenchmarkShards_NoNodes_100kShards(b *testing.B) {
+	host, port, ts := setupTestServers(b, []*ServerSetup{benchmarkShardSetup(100000)})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	var shards []Shard
+
+	for n := 0; n < b.N; n++ {
+		shards, _ = client.GetShards(nil)
+	}
+
+	resultShards = shards
+}
+
+func BenchmarkShards_5Nodes_100Shards(b *testing.B) {
+	host, port, ts := setupTestServers(b, []*ServerSetup{benchmarkShardSetup(100)})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	var shards []Shard
+	var nodes []string
+
+	for i := 0; i < 5; i++ {
+		nodes = append(nodes, fmt.Sprintf("elasticsearch_%d", i))
+	}
+
+	for n := 0; n < b.N; n++ {
+		shards, _ = client.GetShards(nodes)
+	}
+
+	resultShards = shards
+}
+
+func BenchmarkShards_5Nodes_1kShards(b *testing.B) {
+	host, port, ts := setupTestServers(b, []*ServerSetup{benchmarkShardSetup(1000)})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	var shards []Shard
+	var nodes []string
+
+	for i := 0; i < 5; i++ {
+		nodes = append(nodes, fmt.Sprintf("elasticsearch_%d", i))
+	}
+
+	for n := 0; n < b.N; n++ {
+		shards, _ = client.GetShards(nodes)
+	}
+
+	resultShards = shards
+}
+
+func BenchmarkShards_5Nodes_100kShards(b *testing.B) {
+	host, port, ts := setupTestServers(b, []*ServerSetup{benchmarkShardSetup(100000)})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	var shards []Shard
+	var nodes []string
+
+	for i := 0; i < 5; i++ {
+		nodes = append(nodes, fmt.Sprintf("elasticsearch_%d", i))
+	}
+
+	for n := 0; n < b.N; n++ {
+		shards, _ = client.GetShards(nodes)
+	}
+
+	resultShards = shards
 }


### PR DESCRIPTION
This pull requests refactors the `GetShards` command. No functionality should change. 

I wanted to try refactoring this because we tried out some custom JSON parsing to get better performance: https://github.com/github/vulcanizer/commit/1216606bb9a0b7eadcaae82da35179d4dbe99cdd#diff-ac8a869cd6a026dbdc7fa09a769f652bR870

I [added some benchmark tests](https://github.com/github/vulcanizer/pull/46/commits/31f7ad5787bc72fc1a85aed6048fb8db9324d02b) to determine if there was a noticeable difference in using the standard JSON parsing in `handleErrWithStruct`. 

This resulted in about a net equivalent performance, but simplifies the code and uses a standard pattern so I consider it a win:

```
$ benchcmp getShards_Current.txt getShards_Refactor.txt
benchmark                                old ns/op      new ns/op      delta
BenchmarkShards_NoNodes_100Shards-4      3250202        3176202        -2.28%
BenchmarkShards_NoNodes_1kShards-4       7409966        7437430        +0.37%
BenchmarkShards_NoNodes_100kShards-4     394691703      304803750      -22.77%
BenchmarkShards_5Nodes_100Shards-4       3419290        3158018        -7.64%
BenchmarkShards_5Nodes_1kShards-4        21768224       20086054       -7.73%
BenchmarkShards_5Nodes_100kShards-4      1647863268     1879396061     +14.05%

benchmark                                old allocs     new allocs     delta
BenchmarkShards_NoNodes_100Shards-4      790            700            -11.39%
BenchmarkShards_NoNodes_1kShards-4       6216           5233           -15.81%
BenchmarkShards_NoNodes_100kShards-4     600257         500279         -16.66%
BenchmarkShards_5Nodes_100Shards-4       11307          11226          -0.72%
BenchmarkShards_5Nodes_1kShards-4        111252         110286         -0.87%
BenchmarkShards_5Nodes_100kShards-4      11100555       11000595       -0.90%

benchmark                                old bytes      new bytes      delta
BenchmarkShards_NoNodes_100Shards-4      142367         134051         -5.84%
BenchmarkShards_NoNodes_1kShards-4       1327916        1215713        -8.45%
BenchmarkShards_NoNodes_100kShards-4     157976444      109901294      -30.43%
BenchmarkShards_5Nodes_100Shards-4       1850167        1876662        +1.43%
BenchmarkShards_5Nodes_1kShards-4        18108602       18339026       +1.27%
BenchmarkShards_5Nodes_100kShards-4      1759913053     1786803515     +1.53%
```

While doing this, I also notice that we re-create a regex to filter the shards on every loop. So, I pre-compiled the passed node strings and then re-ran the benchmarks with some pretty clear improvements in speed and memory usage.

```
$ benchcmp getShards_Current.txt getShards_Refactor_Compiled.txt
benchmark                                old ns/op      new ns/op     delta
BenchmarkShards_NoNodes_100Shards-4      3250202        3245414       -0.15%
BenchmarkShards_NoNodes_1kShards-4       7409966        7526528       +1.57%
BenchmarkShards_NoNodes_100kShards-4     394691703      294760475     -25.32%
BenchmarkShards_5Nodes_100Shards-4       3419290        3194408       -6.58%
BenchmarkShards_5Nodes_1kShards-4        21768224       6508512       -70.10%
BenchmarkShards_5Nodes_100kShards-4      1647863268     310095775     -81.18%

benchmark                                old allocs     new allocs     delta
BenchmarkShards_NoNodes_100Shards-4      790            700            -11.39%
BenchmarkShards_NoNodes_1kShards-4       6216           5233           -15.81%
BenchmarkShards_NoNodes_100kShards-4     600257         500279         -16.66%
BenchmarkShards_5Nodes_100Shards-4       11307          810            -92.84%
BenchmarkShards_5Nodes_1kShards-4        111252         5345           -95.20%
BenchmarkShards_5Nodes_100kShards-4      11100555       500391         -95.49%

benchmark                                old bytes      new bytes     delta
BenchmarkShards_NoNodes_100Shards-4      142367         134054        -5.84%
BenchmarkShards_NoNodes_1kShards-4       1327916        1215733       -8.45%
BenchmarkShards_NoNodes_100kShards-4     157976444      109901305     -30.43%
BenchmarkShards_5Nodes_100Shards-4       1850167        159496        -91.38%
BenchmarkShards_5Nodes_1kShards-4        18108602       1264255       -93.02%
BenchmarkShards_5Nodes_100kShards-4      1759913053     109955954     -93.75%
```

In this branch, I've reverted the benchmark code as I don't think it's necessary to have around all the time.

