### PR TITLE
Add node version to the `Node` struct, and expose to the CLI `nodes` command

### DIFF
--- a/cmd/vulcanizer/nodes.go
+++ b/cmd/vulcanizer/nodes.go
@@ -27,7 +27,7 @@ var cmdNodes = &cobra.Command{
 			os.Exit(1)
 		}
 
-		header := []string{"Master", "Role", "Name", "Ip", "Id", "JDK"}
+		header := []string{"Master", "Role", "Name", "Ip", "Id", "JDK", "Version"}
 		rows := [][]string{}
 		for _, node := range nodes {
 			row := []string{
@@ -37,6 +37,7 @@ var cmdNodes = &cobra.Command{
 				node.Ip,
 				node.Id,
 				node.Jdk,
+				node.Version,
 			}
 
 			rows = append(rows, row)

--- a/es.go
+++ b/es.go
@@ -40,12 +40,13 @@ type Client struct {
 
 //Holds information about an Elasticsearch node, based on the _cat/nodes API: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-nodes.html
 type Node struct {
-	Name   string `json:"name"`
-	Ip     string `json:"ip"`
-	Id     string `json:"id"`
-	Role   string `json:"role"`
-	Master string `json:"master"`
-	Jdk    string `json:"jdk"`
+	Name    string `json:"name"`
+	Ip      string `json:"ip"`
+	Id      string `json:"id"`
+	Role    string `json:"role"`
+	Master  string `json:"master"`
+	Jdk     string `json:"jdk"`
+	Version string `json:"version"`
 }
 
 //Holds information about an Elasticsearch index, based on the _cat/indices API: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-indices.html
@@ -474,7 +475,7 @@ func (c *Client) FillAll() (ExcludeSettings, error) {
 func (c *Client) GetNodes() ([]Node, error) {
 	var nodes []Node
 
-	agent := c.buildGetRequest("_cat/nodes?h=master,role,name,ip,id,jdk")
+	agent := c.buildGetRequest("_cat/nodes?h=master,role,name,ip,id,jdk,version")
 	err := handleErrWithStruct(agent, &nodes)
 
 	if err != nil {

--- a/es_test.go
+++ b/es_test.go
@@ -257,7 +257,7 @@ func TestGetNodes(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "GET",
 		Path:     "/_cat/nodes",
-		Response: `[{"master": "*", "role": "d", "name": "foo", "ip": "127.0.0.1", "id": "abc", "jdk": "1.8"}]`,
+		Response: `[{"master": "*", "role": "d", "name": "foo", "ip": "127.0.0.1", "id": "abc", "jdk": "1.8", "version": "6.4.0"}]`,
 	}
 
 	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
@@ -276,6 +276,10 @@ func TestGetNodes(t *testing.T) {
 
 	if nodes[0].Name != "foo" {
 		t.Errorf("Unexpected node name, expected foo, got %s", nodes[0].Name)
+	}
+
+	if nodes[0].Version != "6.4.0" {
+		t.Errorf("Unexpected version, expected 6.4.0, got %s", nodes[0].Version)
 	}
 }
 


### PR DESCRIPTION
This PR exposes the ES node version as part of the `Node` struct.