### PR TITLE
Indices features

### DIFF
--- a/cmd/vulcanizer/indices.go
+++ b/cmd/vulcanizer/indices.go
@@ -29,9 +29,9 @@ var cmdIndices = &cobra.Command{
 		var err error
 		var indices []vulcanizer.Index
 		if len(args) > 0 {
-			indices, err = v.GetSomeIndices(args[0])
+			indices, err = v.GetIndices(args[0])
 		} else {
-			indices, err = v.GetIndices()
+			indices, err = v.GetAllIndices()
 		}
 
 		if err != nil {

--- a/cmd/vulcanizer/indices.go
+++ b/cmd/vulcanizer/indices.go
@@ -14,14 +14,23 @@ func init() {
 }
 
 var cmdIndices = &cobra.Command{
-	Use:   "indices",
-	Short: "Display the indices of the cluster.",
-	Long:  `Show what indices are created on the given cluster.`,
+	Use:     "indices",
+	Aliases: []string{"index"},
+	Short:   "Display the indices of the cluster.",
+	Long:    `Show what indices are created on the given cluster.`,
+	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		host, port, auth := getConfiguration()
 		v := vulcanizer.NewClient(host, port)
 		v.Auth = auth
-		indices, err := v.GetIndices()
+
+		var err error
+		var indices []vulcanizer.Index
+		if len(args) > 0 {
+			indices, err = v.GetSomeIndices(args[0])
+		} else {
+			indices, err = v.GetIndices()
+		}
 
 		if err != nil {
 			fmt.Printf("Error getting indices: %s\n", err)

--- a/cmd/vulcanizer/indices.go
+++ b/cmd/vulcanizer/indices.go
@@ -11,6 +11,8 @@ import (
 
 func init() {
 	rootCmd.AddCommand(cmdIndices)
+	cmdIndices.AddCommand(cmdOpen)
+	cmdIndices.AddCommand(cmdClose)
 }
 
 var cmdIndices = &cobra.Command{
@@ -56,5 +58,41 @@ var cmdIndices = &cobra.Command{
 
 		table := renderTable(rows, header)
 		fmt.Println(table)
+	},
+}
+
+var cmdOpen = &cobra.Command{
+	Use:   "open",
+	Short: "Open the given index/indices",
+	Long:  `Given a name or pattern, opens the index/indices`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		host, port, auth := getConfiguration()
+		v := vulcanizer.NewClient(host, port)
+		v.Auth = auth
+
+		err := v.OpenIndex(args[0])
+		if err != nil {
+			fmt.Printf("Error opening index/indices: %s - %s\n", args[0], err)
+			os.Exit(1)
+		}
+	},
+}
+
+var cmdClose = &cobra.Command{
+	Use:   "close",
+	Short: "Close the given index/indices",
+	Long:  `Given a name or pattern, closes the index/indices`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		host, port, auth := getConfiguration()
+		v := vulcanizer.NewClient(host, port)
+		v.Auth = auth
+
+		err := v.CloseIndex(args[0])
+		if err != nil {
+			fmt.Printf("Error opening index/indices: %s - %s\n", args[0], err)
+			os.Exit(1)
+		}
 	},
 }

--- a/es.go
+++ b/es.go
@@ -605,7 +605,7 @@ func (c *Client) CloseIndex(indexName string) error {
 	}
 
 	if !response.Acknowledged {
-		return fmt.Errorf(`Request to open index "%s" was not acknowledged. %+v`, indexName, response)
+		return fmt.Errorf(`Request to close index "%s" was not acknowledged. %+v`, indexName, response)
 	}
 
 	return nil

--- a/es.go
+++ b/es.go
@@ -499,6 +499,18 @@ func (c *Client) GetIndices() ([]Index, error) {
 	return indices, nil
 }
 
+// Get a subset of indices
+func (c *Client) GetSomeIndices(index string) ([]Index, error) {
+	var indices []Index
+	err := handleErrWithStruct(c.buildGetRequest(fmt.Sprintf("_cat/indices/%s?h=health,status,index,pri,rep,store.size,docs.count", index)), &indices)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return indices, nil
+}
+
 //Get all the aliases in the cluster.
 //
 //Use case: You want to see some basic info on all the aliases of the cluster

--- a/es.go
+++ b/es.go
@@ -567,6 +567,50 @@ func (c *Client) DeleteIndex(indexName string) error {
 	return nil
 }
 
+//Open an index on the cluster
+//
+//Use case: You want to open a closed index
+func (c *Client) OpenIndex(indexName string) error {
+	// var response acknowledgedResponse
+
+	var response struct {
+		Acknowledged bool `json:"acknowledged"`
+	}
+	err := handleErrWithStruct(c.buildPostRequest(fmt.Sprintf("%s/_open", indexName)), &response)
+
+	if err != nil {
+		return err
+	}
+
+	if !response.Acknowledged {
+		return fmt.Errorf(`Request to open index "%s" was not acknowledged. %+v`, indexName, response)
+	}
+
+	return nil
+}
+
+//Close an index on the cluster
+//
+//Use case: You want to close an opened index
+func (c *Client) CloseIndex(indexName string) error {
+	// var response acknowledgedResponse
+
+	var response struct {
+		Acknowledged bool `json:"acknowledged"`
+	}
+	err := handleErrWithStruct(c.buildPostRequest(fmt.Sprintf("%s/_close", indexName)), &response)
+
+	if err != nil {
+		return err
+	}
+
+	if !response.Acknowledged {
+		return fmt.Errorf(`Request to open index "%s" was not acknowledged. %+v`, indexName, response)
+	}
+
+	return nil
+}
+
 //Get the health of the cluster.
 //
 //Use case: You want to see information needed to determine if the Elasticsearch cluster is healthy (green) or not (yellow/red).

--- a/es.go
+++ b/es.go
@@ -488,7 +488,7 @@ func (c *Client) GetNodes() ([]Node, error) {
 //Get all the indices in the cluster.
 //
 //Use case: You want to see some basic info on all the indices of the cluster.
-func (c *Client) GetIndices() ([]Index, error) {
+func (c *Client) GetAllIndices() ([]Index, error) {
 	var indices []Index
 	err := handleErrWithStruct(c.buildGetRequest("_cat/indices?h=health,status,index,pri,rep,store.size,docs.count"), &indices)
 
@@ -500,7 +500,7 @@ func (c *Client) GetIndices() ([]Index, error) {
 }
 
 // Get a subset of indices
-func (c *Client) GetSomeIndices(index string) ([]Index, error) {
+func (c *Client) GetIndices(index string) ([]Index, error) {
 	var indices []Index
 	err := handleErrWithStruct(c.buildGetRequest(fmt.Sprintf("_cat/indices/%s?h=health,status,index,pri,rep,store.size,docs.count", index)), &indices)
 
@@ -1094,7 +1094,7 @@ func (c *Client) GetShardOverlap(nodes []string) (map[string]ShardOverlap, error
 		return nil, err
 	}
 
-	_indices, err := c.GetIndices()
+	_indices, err := c.GetAllIndices()
 
 	if err != nil {
 		fmt.Printf("Error getting indices: %s", err)

--- a/es_test.go
+++ b/es_test.go
@@ -283,7 +283,7 @@ func TestGetNodes(t *testing.T) {
 	}
 }
 
-func TestGetIndices(t *testing.T) {
+func TestGetAllIndices(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "GET",
 		Path:     "/_cat/indices",
@@ -294,7 +294,7 @@ func TestGetIndices(t *testing.T) {
 	defer ts.Close()
 	client := NewClient(host, port)
 
-	indices, err := client.GetIndices()
+	indices, err := client.GetAllIndices()
 
 	if err != nil {
 		t.Errorf("Unexpected error expected nil, got %s", err)
@@ -309,7 +309,7 @@ func TestGetIndices(t *testing.T) {
 	}
 }
 
-func TestGetSomeIndices(t *testing.T) {
+func TestGetIndices(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "GET",
 		Path:     "/_cat/indices/test*",
@@ -320,7 +320,7 @@ func TestGetSomeIndices(t *testing.T) {
 	defer ts.Close()
 	client := NewClient(host, port)
 
-	indices, err := client.GetSomeIndices("test*")
+	indices, err := client.GetIndices("test*")
 
 	if err != nil {
 		t.Errorf("Unexpected error expected nil, got %s", err)

--- a/es_test.go
+++ b/es_test.go
@@ -454,6 +454,42 @@ func TestDeleteIndex(t *testing.T) {
 	}
 }
 
+func TestOpenIndex(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "POST",
+		Path:     "/openindex*/_open",
+		Response: `{"acknowledged": true}`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	err := client.OpenIndex("openindex*")
+
+	if err != nil {
+		t.Errorf("Unexpected error expected nil, got %s", err)
+	}
+}
+
+func TestCloseIndex(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "POST",
+		Path:     "/closeindex*/_close",
+		Response: `{"acknowledged": true}`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	err := client.CloseIndex("closeindex*")
+
+	if err != nil {
+		t.Errorf("Unexpected error expected nil, got %s", err)
+	}
+}
+
 func TestGetHealth(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "GET",

--- a/es_test.go
+++ b/es_test.go
@@ -309,6 +309,32 @@ func TestGetIndices(t *testing.T) {
 	}
 }
 
+func TestGetSomeIndices(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "GET",
+		Path:     "/_cat/indices/test*",
+		Response: `[{"health":"yellow","status":"open","index":"test_one","pri":"5","rep":"1","store.size":"3.6kb", "docs.count":"1500"}]`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	indices, err := client.GetSomeIndices("test*")
+
+	if err != nil {
+		t.Errorf("Unexpected error expected nil, got %s", err)
+	}
+
+	if len(indices) != 1 {
+		t.Errorf("Unexpected indices, got %v", indices)
+	}
+
+	if indices[0].Health != "yellow" || indices[0].ReplicaCount != 1 || indices[0].DocumentCount != 1500 {
+		t.Errorf("Unexpected index values, got %v", indices[0])
+	}
+}
+
 func TestGetAliases(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "GET",

--- a/integration_test.go
+++ b/integration_test.go
@@ -25,7 +25,7 @@ func TestNodes(t *testing.T) {
 func TestIndices(t *testing.T) {
 	c := vulcanizer.NewClient("localhost", 49200)
 
-	indices, err := c.GetIndices()
+	indices, err := c.GetAllIndices()
 
 	if err != nil {
 		t.Fatalf("Error getting indices: %s", err)
@@ -60,7 +60,7 @@ func TestIndices(t *testing.T) {
 		}
 	}
 
-	indices, err = c.GetIndices()
+	indices, err = c.GetAllIndices()
 	if err != nil {
 		t.Fatalf("Error getting indices: %s", err)
 	}
@@ -266,7 +266,7 @@ func TestSnapshots(t *testing.T) {
 	// Let the restore complete
 	time.Sleep(5 * time.Second)
 
-	indices, err := c.GetIndices()
+	indices, err := c.GetAllIndices()
 
 	if err != nil {
 		t.Fatalf("Error getting indices: %s", err)
@@ -295,7 +295,7 @@ func TestSnapshots(t *testing.T) {
 		t.Fatalf("Error deleting restored_integration_test index: %+v", indices)
 	}
 
-	indices, err = c.GetIndices()
+	indices, err = c.GetAllIndices()
 	if err != nil {
 		t.Fatalf("Error getting indices after index deletion: %s", err)
 	}


### PR DESCRIPTION
I was hoping to use the tool to carry out operations such as listing only specific indices, and opening and closing indices.

Added 

es.go
  - GetSomeIndices() to retrieve partial list of indices, given a pattern, eg. `someindex-2018*`
  - OpenIndex() to open an index/indices, given a pattern
  - CloseIndex() to close an index/indices, given a pattern

es_test.go
  - Tests for GetSomeIndices(), OpenIndex(), and CloseIndex()


Modified
cmd/vulcanizer/indices.go
  - Modified `indices` command to optionally take a pattern as a parameter, specifying a subset of indices to return
  - Added alias `index` to `indices` command
  - Added `open` and `close` subcommands to `indices`/`index`, wrapping `OpenIndex()` and `CloseIndex()` from `es.go`