### PR TITLE
Configuration handling tweaks

### DIFF
--- a/cmd/vulcanizer/aliases.go
+++ b/cmd/vulcanizer/aliases.go
@@ -92,9 +92,8 @@ var cmdAliasesList = &cobra.Command{
 	Short: "Display the aliases of the cluster",
 	Long:  `Show what aliases are created on the given cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+		v := getClient()
+
 		aliases, err := v.GetAliases()
 
 		if err != nil {
@@ -127,9 +126,8 @@ var cmdAliasesUpdate = &cobra.Command{
 	Short: "Update an index's alias",
 	Long:  `In one atomic operation delete an existing alias and create a new one for a given index on the given cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		indexName, err := cmd.Flags().GetString("index")
 		if err != nil {
@@ -175,9 +173,8 @@ var cmdAliasesAdd = &cobra.Command{
 	Short: "Add an alias",
 	Long:  `Add a new alias to a given index in the given cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		indexName, err := cmd.Flags().GetString("index")
 		if err != nil {
@@ -212,9 +209,8 @@ var cmdAliasesDelete = &cobra.Command{
 	Short: "Delete an alias",
 	Long:  `Delete an alias associated to a given index in the given cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		indexName, err := cmd.Flags().GetString("index")
 		if err != nil || indexName == "" {

--- a/cmd/vulcanizer/allocation.go
+++ b/cmd/vulcanizer/allocation.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/github/vulcanizer"
 	"github.com/spf13/cobra"
 )
 
@@ -24,9 +23,9 @@ var cmdAllocationEnable = &cobra.Command{
 	Short: "Enable allocation on the cluster.",
 	Long:  `This commands enables allocation on the given cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
+
 		response, err := v.SetAllocation("enable")
 		if err != nil {
 			fmt.Printf("Error setting allocation: %s \n", err)
@@ -42,9 +41,9 @@ var cmdAllocationDisable = &cobra.Command{
 	Short: "Disable allocation on the cluster.",
 	Long:  `This commands disables allocation on the given cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
+
 		response, err := v.SetAllocation("disable")
 		if err != nil {
 			fmt.Printf("Error setting allocation: %s \n", err)

--- a/cmd/vulcanizer/analyze.go
+++ b/cmd/vulcanizer/analyze.go
@@ -30,9 +30,8 @@ var cmdAnalyze = &cobra.Command{
 	Short: "Analyze text given an analyzer or a field and index.",
 	Long:  `Use Elasticsearch's analyze API to display the tokens of example text. Either "analyzer" OR "field" and "index" arguments are required.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		text, err := cmd.Flags().GetString("text")
 		if err != nil {

--- a/cmd/vulcanizer/drain.go
+++ b/cmd/vulcanizer/drain.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/github/vulcanizer"
 	"github.com/spf13/cobra"
 )
 
@@ -33,9 +32,9 @@ var cmdDrainServer = &cobra.Command{
 	Short: "Drain a server by excluding shards from it.",
 	Long:  `This command will set the shard allocation rules to exclude the given server name. This will cause shards to be moved away from this server, draining the data away.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
+
 		fmt.Printf("drain server name is: %s\n", serverToDrain)
 
 		excludedServers, err := v.DrainServer(serverToDrain)
@@ -53,9 +52,9 @@ var cmdDrainStatus = &cobra.Command{
 	Short: "See what servers are set to drain.",
 	Long:  `This command will display what servers are set in the clusters allocation exclude rules.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
+
 		excludeSettings, err := v.GetClusterExcludeSettings()
 		if err != nil {
 			fmt.Printf("Error getting exclude settings: %s \n", err)

--- a/cmd/vulcanizer/fill.go
+++ b/cmd/vulcanizer/fill.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/github/vulcanizer"
 	"github.com/spf13/cobra"
 )
 
@@ -33,9 +32,8 @@ var cmdFillAll = &cobra.Command{
 	Short: "Fill all servers with data, removing all exclusion rules.",
 	Long:  `This command will remove all shard allocation exclusion rules from the cluster, allowing all servers to fill with data.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		excludeSettings, err := v.FillAll()
 		if err != nil {
@@ -52,9 +50,8 @@ var cmdFillServer = &cobra.Command{
 	Short: "Fill one server with data, removing exclusion rules from it.",
 	Long:  `This command will remove shard allocation exclusion rules from a particular Elasticsearch node, allowing shards to allocated to it.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		excludeSettings, err := v.FillOneServer(serverToFill)
 		if err != nil {

--- a/cmd/vulcanizer/health.go
+++ b/cmd/vulcanizer/health.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/github/vulcanizer"
 	"github.com/spf13/cobra"
 )
 
@@ -18,9 +17,9 @@ var cmdHealth = &cobra.Command{
 	Short: "Display the health of the cluster.",
 	Long:  `Get detailed information about what constitutes the health of the cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
+
 		health, err := v.GetHealth()
 
 		if err != nil {

--- a/cmd/vulcanizer/indices.go
+++ b/cmd/vulcanizer/indices.go
@@ -22,9 +22,8 @@ var cmdIndices = &cobra.Command{
 	Long:    `Show what indices are created on the given cluster.`,
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		var err error
 		var indices []vulcanizer.Index
@@ -67,9 +66,8 @@ var cmdOpen = &cobra.Command{
 	Long:  `Given a name or pattern, opens the index/indices`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		err := v.OpenIndex(args[0])
 		if err != nil {
@@ -85,9 +83,8 @@ var cmdClose = &cobra.Command{
 	Long:  `Given a name or pattern, closes the index/indices`,
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		err := v.CloseIndex(args[0])
 		if err != nil {

--- a/cmd/vulcanizer/main.go
+++ b/cmd/vulcanizer/main.go
@@ -23,7 +23,6 @@ type Config struct {
 }
 
 func getConfiguration() Config {
-	var config Config
 
 	v := viper.GetViper()
 
@@ -34,9 +33,15 @@ func getConfiguration() Config {
 			fmt.Printf("Could not retrieve configuration for cluster \"%s\"\n", viper.GetString("cluster"))
 			os.Exit(1)
 		}
+
+		err := v.BindPFlags(rootCmd.PersistentFlags())
+		if err != nil {
+			fmt.Printf("Could not bind commandline flags to configuration: %s\n", err)
+		}
+
 	}
 
-	config = Config{
+	config := Config{
 		Host:     v.GetString("host"),
 		Port:     v.GetInt("port"),
 		Protocol: v.GetString("protocol"),
@@ -47,6 +52,7 @@ func getConfiguration() Config {
 
 		TLSSkipVerify: v.GetBool("skipverify"),
 	}
+
 	return config
 }
 

--- a/cmd/vulcanizer/main.go
+++ b/cmd/vulcanizer/main.go
@@ -115,17 +115,17 @@ func main() {
 	}
 	err = viper.BindPFlag("path", rootCmd.PersistentFlags().Lookup("path"))
 	if err != nil {
-		fmt.Printf("Error binding cluster configuration flag: %s \n", err)
+		fmt.Printf("Error binding path flag: %s \n", err)
 		os.Exit(1)
 	}
 	err = viper.BindPFlag("protocol", rootCmd.PersistentFlags().Lookup("protocol"))
 	if err != nil {
-		fmt.Printf("Error binding cluster configuration flag: %s \n", err)
+		fmt.Printf("Error binding protocol flag: %s \n", err)
 		os.Exit(1)
 	}
 	err = viper.BindPFlag("skipverify", rootCmd.PersistentFlags().Lookup("skipverify"))
 	if err != nil {
-		fmt.Printf("Error binding cluster configuration flag: %s \n", err)
+		fmt.Printf("Error binding skipverify flag: %s \n", err)
 		os.Exit(1)
 	}
 	err = viper.BindPFlag("user", rootCmd.PersistentFlags().Lookup("user"))

--- a/cmd/vulcanizer/main.go
+++ b/cmd/vulcanizer/main.go
@@ -11,35 +11,35 @@ import (
 	"github.com/spf13/viper"
 )
 
-func getConfiguration() (string, int, *vulcanizer.Auth) {
-	var host string
-	var port int
-	var auth vulcanizer.Auth
+type Config struct {
+	Host     string
+	Port     int
+	User     string
+	Password string
+}
+
+func getConfiguration() Config {
+	var config Config
+
+	v := viper.GetViper()
 
 	if viper.GetString("cluster") != "" {
-		config := viper.Sub(viper.GetString("cluster"))
+		v = viper.Sub(viper.GetString("cluster"))
 
-		if config == nil {
+		if v == nil {
 			fmt.Printf("Could not retrieve configuration for cluster \"%s\"\n", viper.GetString("cluster"))
 			os.Exit(1)
 		}
-
-		host = config.GetString("host")
-		port = config.GetInt("port")
-		auth = vulcanizer.Auth{
-			User:     config.GetString("user"),
-			Password: config.GetString("password"),
-		}
-	} else {
-		host = viper.GetString("host")
-		port = viper.GetInt("port")
-		auth = vulcanizer.Auth{
-			User:     viper.GetString("user"),
-			Password: viper.GetString("password"),
-		}
 	}
 
-	return host, port, &auth
+	config = Config{
+		Host: v.GetString("host"),
+		Port: v.GetInt("port"),
+
+		User:     v.GetString("user"),
+		Password: v.GetString("password"),
+	}
+	return config
 }
 
 func renderTable(rows [][]string, header []string) string {

--- a/cmd/vulcanizer/main.go
+++ b/cmd/vulcanizer/main.go
@@ -50,6 +50,28 @@ func getConfiguration() Config {
 	return config
 }
 
+func getClient() *vulcanizer.Client {
+
+	c := getConfiguration()
+
+	v := vulcanizer.NewClient(
+		c.Host,
+		c.Port,
+	)
+	v.Path = c.Path
+	v.Auth = &vulcanizer.Auth{User: c.User, Password: c.Password}
+
+	if c.Protocol == "https" {
+		v.Secure = true
+	}
+
+	if c.TLSSkipVerify {
+		v.TLSConfig = &tls.Config{InsecureSkipVerify: c.TLSSkipVerify}
+	}
+
+	return v
+}
+
 func renderTable(rows [][]string, header []string) string {
 	var result bytes.Buffer
 	table := tablewriter.NewWriter(&result)

--- a/cmd/vulcanizer/nodes.go
+++ b/cmd/vulcanizer/nodes.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/github/vulcanizer"
 	"github.com/spf13/cobra"
 )
 
@@ -17,9 +16,9 @@ var cmdNodes = &cobra.Command{
 	Short: "Display the nodes of the cluster.",
 	Long:  `Show what nodes are part of the cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
+
 		nodes, err := v.GetNodes()
 
 		if err != nil {

--- a/cmd/vulcanizer/repository.go
+++ b/cmd/vulcanizer/repository.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/github/vulcanizer"
 	"github.com/spf13/cobra"
 )
 
@@ -39,9 +38,8 @@ var cmdRepositoryVerify = &cobra.Command{
 	Short: "Verify the specified repository.",
 	Long:  `This command will verify the repository is configured correctly on all nodes.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		repository, err := cmd.Flags().GetString("repository")
 		if err != nil {
@@ -69,9 +67,8 @@ var cmdRepositoryList = &cobra.Command{
 	Short: "List configured snapshot repositories.",
 	Long:  `This command will list all the the snapshot repositories on the cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		repos, err := v.GetRepositories()
 		if err != nil {

--- a/cmd/vulcanizer/setting.go
+++ b/cmd/vulcanizer/setting.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/github/vulcanizer"
 	"github.com/spf13/cobra"
 )
 
@@ -41,9 +40,8 @@ var cmdSettingUpdate = &cobra.Command{
 	Short: "Update a cluster setting.",
 	Long:  `This command will update the cluster's settings with the provided value.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		existingValue, newValue, err := v.SetClusterSetting(settingToUpdate, valueToUpdate)
 

--- a/cmd/vulcanizer/settings.go
+++ b/cmd/vulcanizer/settings.go
@@ -39,9 +39,8 @@ var cmdSettings = &cobra.Command{
 	Short: "Display all the settings of the cluster.",
 	Long:  `This command displays all the transient and persistent settings that have been set on the given cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		clusterSettings, err := v.GetClusterSettings()
 

--- a/cmd/vulcanizer/shards.go
+++ b/cmd/vulcanizer/shards.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/github/vulcanizer"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -24,9 +23,9 @@ var cmdShards = &cobra.Command{
 	Short: "Get shard data by cluster node(s).",
 	Long:  `This command gets shard related data by node from the cluster.  Default is to return all shards.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
+
 		shards, err := v.GetShards(nodesToCheck)
 
 		if err != nil {
@@ -61,9 +60,9 @@ var cmdShardsRecovery = &cobra.Command{
 	Short: "Get shard recovery status",
 	Long:  `This command gets shard recovery status from the cluster.  Default is to return all shards.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
+
 		recovery, err := v.GetShardRecovery(nodesToCheck, activeOnly)
 
 		if err != nil {

--- a/cmd/vulcanizer/snapshot.go
+++ b/cmd/vulcanizer/snapshot.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/github/vulcanizer"
 	"github.com/spf13/cobra"
 )
 
@@ -111,9 +110,8 @@ var cmdSnapshotStatus = &cobra.Command{
 	Short: "Display info about a snapshot.",
 	Long:  `This command will display detailed information about the given snapshot.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		snapshotName, err := cmd.Flags().GetString("snapshot")
 		if err != nil {
@@ -154,9 +152,8 @@ var cmdSnapshotRestore = &cobra.Command{
 	Short: "Restore a snapshot.",
 	Long:  `This command will restore a specific index from a snapshot to the cluster.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		snapshotName, err := cmd.Flags().GetString("snapshot")
 		if err != nil {
@@ -197,9 +194,8 @@ var cmdSnapshotList = &cobra.Command{
 	Short: "Display the snapshots of the cluster.",
 	Long:  `List the 10 most recent snapshots of the given repository`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		repository, err := cmd.Flags().GetString("repository")
 		if err != nil {
@@ -240,9 +236,8 @@ var cmdSnapshotCreate = &cobra.Command{
 	Short: "Create a new snapshot.",
 	Long:  `This command will take a new snapshot of the data of either all or specified indices.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		host, port, auth := getConfiguration()
-		v := vulcanizer.NewClient(host, port)
-		v.Auth = auth
+
+		v := getClient()
 
 		snapshotName, err := cmd.Flags().GetString("snapshot")
 		if err != nil {

--- a/es.go
+++ b/es.go
@@ -33,6 +33,7 @@ type Client struct {
 	Host      string
 	Port      int
 	Secure    bool
+	Path      string
 	TLSConfig *tls.Config
 	Timeout   time.Duration
 	*Auth
@@ -336,6 +337,10 @@ func (c *Client) getAgent(method, path string) *gorequest.SuperAgent {
 		protocol = "https"
 	} else {
 		protocol = "http"
+	}
+
+	if c.Path != "" {
+		path = fmt.Sprintf("%s/%s", c.Path, path)
 	}
 
 	if c.Port > 0 {


### PR DESCRIPTION
I wanted a way for `vulcanizer` to be able to handle custom paths, protocol tweaks, and skipping of TLS certificate verification.

I added those as options, `--path`, `--protocol` and `-k/--skipverify` to the `cmd/vulcanizer` client, and added support for custom paths in the ES client.

Along the way, I realised to support more of such options, it might be better to introduce a `Config` struct that allows passing of these values from Viper, to the ES client.

To avoid repeating boilerplate code in retrieving the configuration and initialising a new `Client` in each command, I've introduced `getClient()` in `cmd/vulcanizer`, which simply returns a `Client` that's already initialised with the configuration options.