### PR TITLE
Get a subset of aliases

### DIFF
--- a/cmd/vulcanizer/aliases.go
+++ b/cmd/vulcanizer/aliases.go
@@ -91,10 +91,17 @@ var cmdAliasesList = &cobra.Command{
 	Use:   "list",
 	Short: "Display the aliases of the cluster",
 	Long:  `Show what aliases are created on the given cluster.`,
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		v := getClient()
 
-		aliases, err := v.GetAliases()
+		var err error
+		var aliases []vulcanizer.Alias
+		if len(args) > 0 {
+			aliases, err = v.GetAllAliases()
+		} else {
+			aliases, err = v.GetAliases(args[0])
+		}
 
 		if err != nil {
 			fmt.Printf("Error getting aliases: %s\n", err)

--- a/es.go
+++ b/es.go
@@ -519,10 +519,26 @@ func (c *Client) GetIndices(index string) ([]Index, error) {
 //Get all the aliases in the cluster.
 //
 //Use case: You want to see some basic info on all the aliases of the cluster
-func (c *Client) GetAliases() ([]Alias, error) {
+func (c *Client) GetAllAliases() ([]Alias, error) {
 	var aliases []Alias
 
 	err := handleErrWithStruct(c.buildGetRequest("_cat/aliases?h=alias,index,filter,routing.index,routing.search"), &aliases)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return aliases, nil
+}
+
+//Get a subset the aliases in the cluster.
+//
+//Use case: You want to see some basic info on a subset of the aliases of the cluster
+func (c *Client) GetAliases(alias string) ([]Alias, error) {
+	var aliases []Alias
+
+	path := fmt.Sprintf("_cat/aliases/%s?h=alias,index,filter,routing.index,routing.search", alias)
+	err := handleErrWithStruct(c.buildGetRequest(path), &aliases)
 
 	if err != nil {
 		return nil, err

--- a/es_test.go
+++ b/es_test.go
@@ -335,7 +335,7 @@ func TestGetIndices(t *testing.T) {
 	}
 }
 
-func TestGetAliases(t *testing.T) {
+func TestGetAllAliases(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method:   "GET",
 		Path:     "/_cat/aliases",
@@ -346,7 +346,37 @@ func TestGetAliases(t *testing.T) {
 	defer ts.Close()
 	client := NewClient(host, port)
 
-	aliases, err := client.GetAliases()
+	aliases, err := client.GetAllAliases()
+
+	if err != nil {
+		t.Errorf("Unexpected error expected nil, got %s", err)
+	}
+
+	if len(aliases) != 2 {
+		t.Errorf("Unexpected aliases, got %v", aliases)
+	}
+
+	if aliases[0].Name != "test" || aliases[0].IndexName != "test_v1" || aliases[0].Filter != "-filter" || aliases[0].RoutingIndex != "-routing.index" || aliases[0].RoutingSearch != "-routing.search" {
+		t.Errorf("Unexpected index values, got %v", aliases[0])
+	}
+
+	if aliases[1].Name != "test_again" || aliases[1].IndexName != "test_again_v1" || aliases[1].Filter != "--filter" || aliases[1].RoutingIndex != "--routing.index" || aliases[1].RoutingSearch != "--routing.search" {
+		t.Errorf("Unexpected index values, got %v", aliases[1])
+	}
+}
+
+func TestGetAliases(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method:   "GET",
+		Path:     "/_cat/aliases/test*",
+		Response: `[{"alias": "test","index": "test_v1","filter": "-filter","routing.index": "-routing.index","routing.search": "-routing.search"},{"alias": "test_again","index": "test_again_v1","filter": "--filter","routing.index": "--routing.index","routing.search": "--routing.search"}]`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	aliases, err := client.GetAliases("test*")
 
 	if err != nil {
 		t.Errorf("Unexpected error expected nil, got %s", err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -73,7 +73,7 @@ func TestIndices(t *testing.T) {
 func TestAliases(t *testing.T) {
 	c := vulcanizer.NewClient("localhost", 49200)
 
-	aliases, err := c.GetAliases()
+	aliases, err := c.GetAllAliases()
 
 	if err != nil {
 		t.Fatalf("Error getting aliases: %s", err)
@@ -114,7 +114,7 @@ func TestAliasesAddDeleteUpdate(t *testing.T) {
 			t.Fatalf("Error modifying aliases: %s", err)
 		}
 
-		aliases, err := c.GetAliases()
+		aliases, err := c.GetAllAliases()
 		if err != nil {
 			t.Fatalf("Error getting aliases: %s", err)
 		}
@@ -146,7 +146,7 @@ func TestAliasesAddDeleteUpdate(t *testing.T) {
 			t.Fatalf("Error modifying aliases: %s", err)
 		}
 
-		aliases, err := c.GetAliases()
+		aliases, err := c.GetAllAliases()
 		if err != nil {
 			t.Fatalf("Error getting aliases: %s", err)
 		}
@@ -170,7 +170,7 @@ func TestAliasesAddDeleteUpdate(t *testing.T) {
 			t.Fatalf("Error modifying aliases: %s", err)
 		}
 
-		aliases, err := c.GetAliases()
+		aliases, err := c.GetAllAliases()
 		if err != nil {
 			t.Fatalf("Error getting aliases: %s", err)
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -170,7 +170,7 @@ func TestAliasesAddDeleteUpdate(t *testing.T) {
 			t.Fatalf("Error modifying aliases: %s", err)
 		}
 
-		aliases, err := c.GetAllAliases()
+		aliases, err := c.GetAliases("integration_test*")
 		if err != nil {
 			t.Fatalf("Error getting aliases: %s", err)
 		}


### PR DESCRIPTION
This PR changes the `GetAliases()` function to `GetAllAliases()` and adds a new function `GetAliases(string)` that returns a subset of all aliases matching the string.

This matches the recent change that made `GetAllIndices()` and `GetIndices(string)` and since vulcanizer hasn't had a release since `GetAliases` was introduced, I wanted to make the change beforehand.