### PR TITLE
Fix "aliases list"

### DIFF
--- a/cmd/vulcanizer/aliases.go
+++ b/cmd/vulcanizer/aliases.go
@@ -98,9 +98,9 @@ var cmdAliasesList = &cobra.Command{
 		var err error
 		var aliases []vulcanizer.Alias
 		if len(args) > 0 {
-			aliases, err = v.GetAllAliases()
-		} else {
 			aliases, err = v.GetAliases(args[0])
+		} else {
+			aliases, err = v.GetAllAliases()
 		}
 
 		if err != nil {


### PR DESCRIPTION
currently fails with:
```
$ vulcanizer aliases list 
panic: runtime error: index out of range

goroutine 1 [running]:
main.glob..func1(0xd105a0, 0xd39e20, 0x0, 0x0)
	.../go/src/github.com/github/vulcanizer/cmd/vulcanizer/aliases.go:103 +0x46f
```