### PR TITLE
Escape periods in index names as it interferes with gjson

### DIFF
--- a/es.go
+++ b/es.go
@@ -991,7 +991,7 @@ func (c *Client) GetPrettyIndexSettings(index string) (string, error) {
 		return "", err
 	}
 
-	rawSettings := gjson.GetBytes(body, fmt.Sprintf("%s.settings.index", index)).Raw
+	rawSettings := gjson.GetBytes(body, fmt.Sprintf("%s.settings.index", escapeIndexName(index))).Raw
 
 	var prettyPrinted bytes.Buffer
 	err = json.Indent(&prettyPrinted, []byte(rawSettings), "", "  ")
@@ -1012,7 +1012,7 @@ func (c *Client) GetIndexSettings(index string) ([]Setting, error) {
 		return nil, err
 	}
 
-	rawSettings := gjson.GetBytes(body, fmt.Sprintf("%s.settings.index", index)).Raw
+	rawSettings := gjson.GetBytes(body, fmt.Sprintf("%s.settings.index", escapeIndexName(index))).Raw
 
 	settings, err := settingsToStructs(rawSettings)
 
@@ -1029,7 +1029,7 @@ func (c *Client) SetIndexSetting(index, setting, value string) (string, string, 
 		return "", "", err
 	}
 
-	currentValue := gjson.GetBytes(body, fmt.Sprintf("%s.settings.index.%s", index, setting)).Str
+	currentValue := gjson.GetBytes(body, fmt.Sprintf("%s.settings.index.%s", escapeIndexName(index), setting)).Str
 
 	agent := c.buildPutRequest(settingsPath).Set("Content-Type", "application/json").
 		Send(fmt.Sprintf(`{"index" : { "%s" : "%s"}}`, setting, value))

--- a/util.go
+++ b/util.go
@@ -63,3 +63,7 @@ func combineErrors(errs []error) error {
 	}
 	return errors.New(strings.Join(errorText, "\n"))
 }
+
+func escapeIndexName(index string) string {
+	return strings.ReplaceAll(index, ".", "\\.")
+}

--- a/util.go
+++ b/util.go
@@ -65,5 +65,5 @@ func combineErrors(errs []error) error {
 }
 
 func escapeIndexName(index string) string {
-	return strings.ReplaceAll(index, ".", "\\.")
+	return strings.Replace(index, ".", "\\.", -1)
 }

--- a/util_test.go
+++ b/util_test.go
@@ -60,3 +60,17 @@ Third error`
 		t.Errorf("Unexpected error message, got %s", combinedError.Error())
 	}
 }
+
+func TestEscapeIndexName(t *testing.T) {
+	if escapeIndexName(".secret-index") != "\\.secret-index" {
+		t.Errorf("Index name not escaped.")
+	}
+
+	if escapeIndexName(".multiple.periods.in.index") != "\\.multiple\\.periods\\.in\\.index" {
+		t.Errorf("Index name not escaped.")
+	}
+
+	if escapeIndexName("regular-index") != "regular-index" {
+		t.Errorf("Index name changed when it shouldn't have.")
+	}
+}


### PR DESCRIPTION
This PR escapes index names when calling into the `gjson`. Periods interfere with the json path query language and Elasticsearch does have a pattern of using periods in index names.

Closes https://github.com/github/vulcanizer/issues/62