### PR TITLE
Add Allocation/Disk Usage information to Nodes

### DIFF
--- a/es.go
+++ b/es.go
@@ -39,15 +39,34 @@ type Client struct {
 	*Auth
 }
 
-//Holds information about an Elasticsearch node, based on the _cat/nodes API: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-nodes.html
+//Holds information about an Elasticsearch node, based on a combination of the _cat/nodes and _cat/allocationAPI: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-nodes.html, https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-allocation.html
 type Node struct {
-	Name    string `json:"name"`
-	Ip      string `json:"ip"`
-	Id      string `json:"id"`
-	Role    string `json:"role"`
-	Master  string `json:"master"`
-	Jdk     string `json:"jdk"`
-	Version string `json:"version"`
+	Name        string `json:"name"`
+	Ip          string `json:"ip"`
+	Id          string `json:"id"`
+	Role        string `json:"role"`
+	Master      string `json:"master"`
+	Jdk         string `json:"jdk"`
+	Version     string `json:"version"`
+	Shards      string
+	DiskIndices string
+	DiskUsed    string
+	DiskAvail   string
+	DiskTotal   string
+	DiskPercent string
+}
+
+// DiskAllocation holds disk allocation information per node, based on _cat/allocationAPI: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-allocation.html
+type DiskAllocation struct {
+	Name        string `json:"name"`
+	Ip          string `json:"ip"`
+	Node        string `json:"node"`
+	Shards      string `json:"shards"`
+	DiskIndices string `json:"disk.indices"`
+	DiskUsed    string `json:"disk.used"`
+	DiskAvail   string `json:"disk.avail"`
+	DiskTotal   string `json:"disk.total"`
+	DiskPercent string `json:"disk.percent"`
 }
 
 //Holds information about an Elasticsearch index, based on the _cat/indices API: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/cat-indices.html

--- a/es.go
+++ b/es.go
@@ -217,8 +217,8 @@ type acknowledgedResponse struct {
 type Snapshot struct {
 	State          string    `json:"state"`
 	Name           string    `json:"snapshot"`
-	StartTime      time.Time `json:"start_time,string"`
-	EndTime        time.Time `json:"end_time,string"`
+	StartTime      time.Time `json:"start_time"`
+	EndTime        time.Time `json:"end_time"`
 	DurationMillis int       `json:"duration_in_millis"`
 	Indices        []string  `json:"indices"`
 	Shards         struct {

--- a/pkg/cli/node_allocation.go
+++ b/pkg/cli/node_allocation.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(cmdNodeAllocations)
+}
+
+var cmdNodeAllocations = &cobra.Command{
+	Use:   "nodeallocations",
+	Short: "Display the nodes of the cluster and their disk usage/allocation.",
+	Long:  `Show disk allocation of the cluster.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		v := getClient()
+
+		nodes, err := v.GetNodeAllocations()
+
+		if err != nil {
+			fmt.Printf("Error getting nodes: %s\n", err)
+			os.Exit(1)
+		}
+
+		header := []string{"Master", "Role", "Name", "Disk Avail", "Disk Indices", "Disk Percent", "Disk Total", "Disk Used", "Shards", "Ip", "Id", "JDK", "Version"}
+		rows := [][]string{}
+		for _, node := range nodes {
+			row := []string{
+				node.Master,
+				node.Role,
+				node.Name,
+				node.DiskAvail,
+				node.DiskIndices,
+				node.DiskPercent,
+				node.DiskTotal,
+				node.DiskUsed,
+				node.Shards,
+				node.Ip,
+				node.Id,
+				node.Jdk,
+				node.Version,
+			}
+
+			rows = append(rows, row)
+		}
+
+		table := renderTable(rows, header)
+		fmt.Println(table)
+	},
+}

--- a/util.go
+++ b/util.go
@@ -56,6 +56,33 @@ func captionHealth(clusterHealth ClusterHealth) (caption string) {
 	}
 }
 
+func enrichNodesWithAllocations(nodes []Node, allocations []DiskAllocation) []Node {
+	var enrichedNodes []Node
+	nodeAllocation := make(map[string]DiskAllocation)
+	for _, alloc := range allocations {
+		nodeAllocation[alloc.Node] = alloc
+	}
+	for _, node := range nodes {
+		enrichedNode := Node{
+			Name:        node.Name,
+			Ip:          node.Ip,
+			Id:          node.Id,
+			Role:        node.Role,
+			Master:      node.Master,
+			Jdk:         node.Jdk,
+			Version:     node.Version,
+			Shards:      nodeAllocation[node.Name].Shards,
+			DiskIndices: nodeAllocation[node.Name].DiskIndices,
+			DiskUsed:    nodeAllocation[node.Name].DiskUsed,
+			DiskAvail:   nodeAllocation[node.Name].DiskAvail,
+			DiskTotal:   nodeAllocation[node.Name].DiskTotal,
+			DiskPercent: nodeAllocation[node.Name].DiskPercent,
+		}
+		enrichedNodes = append(enrichedNodes, enrichedNode)
+	}
+	return enrichedNodes
+}
+
 func combineErrors(errs []error) error {
 	errorText := []string{}
 	for _, err := range errs {


### PR DESCRIPTION
This PR adds Node allocation information from the `_cat/allocation` API to the existing Node struct. It adds a new function called `GetNodeAllocations` that first calls the `GetNodes()` function and then enriches the Node struct with a call to `_cat/allocation`.

If you want to keep the `Node` struct as a pure map of what the `_cat/nodes` API returns I can split the struct in to a separate thing, or just use the intermediate `DiskAllocation` struct as a return value for `GetNodeAllocations` but my thinking was that I wanted as much information as possible when calling `GetNodeAllocation`, otherwise it's almost just a `cURL` wrapper.

I also added a `vulcanizer nodeallocations` cmd command just to test it. Not sure it's a very good name for it, but I couldn't come up with anything better. We could perhaps have the disk allocation information as a flag to `vulcanizer nodes`? Didn't want to mess with it too much right away before I had settled on the actual allocation function and gotten some feedback.

Any feedback appreciated! I'm sure there's some nicer/tidier/more idiomatic ways to solve this, so please let me know!