### PR TITLE
Add simple slice sorting based on node.Name before we return node tables

### DIFF
--- a/pkg/cli/node_allocation.go
+++ b/pkg/cli/node_allocation.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,9 @@ var cmdNodeAllocations = &cobra.Command{
 
 		header := []string{"Master", "Role", "Name", "Disk Avail", "Disk Indices", "Disk Percent", "Disk Total", "Disk Used", "Shards", "Ip", "Id", "JDK", "Version"}
 		rows := [][]string{}
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[i].Name < nodes[j].Name
+		})
 		for _, node := range nodes {
 			row := []string{
 				node.Master,

--- a/pkg/cli/nodes.go
+++ b/pkg/cli/nodes.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/spf13/cobra"
 )
@@ -28,6 +29,9 @@ var cmdNodes = &cobra.Command{
 
 		header := []string{"Master", "Role", "Name", "Ip", "Id", "JDK", "Version"}
 		rows := [][]string{}
+		sort.Slice(nodes, func(i, j int) bool {
+			return nodes[i].Name < nodes[j].Name
+		})
 		for _, node := range nodes {
 			row := []string{
 				node.Master,


### PR DESCRIPTION
This is a tiny PR that sorts the node and node allocation output by Node Name. I was getting the nodes returned in random order (as is expected of course) and it was hard to track changes in disk usage that way. This is just a crude sort in front of the output section.

Feel free to not merge if there's some better way of doing this!