### PR TITLE
Allow null settings in ES when using SetClusterSetting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/tidwall/gjson v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/cli/entrypoint.go
+++ b/pkg/cli/entrypoint.go
@@ -5,11 +5,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/github/vulcanizer"
 	"io"
 	"io/ioutil"
 	"os"
 
+	"github.com/github/vulcanizer"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -111,6 +111,13 @@ func getClient() *vulcanizer.Client {
 	}
 
 	return v
+}
+
+func printableNil(ptrValue *string) string {
+	if ptrValue == nil {
+		return "null"
+	}
+	return *ptrValue
 }
 
 func renderTable(rows [][]string, header []string) string {

--- a/pkg/cli/setting.go
+++ b/pkg/cli/setting.go
@@ -9,6 +9,8 @@ import (
 
 var settingToUpdate, valueToUpdate string
 
+var removeValue bool
+
 func init() {
 
 	cmdSettingUpdate.Flags().StringVarP(&settingToUpdate, "setting", "s", "", "Elasticsearch cluster setting to update (required)")
@@ -18,12 +20,9 @@ func init() {
 		os.Exit(1)
 	}
 
-	cmdSettingUpdate.Flags().StringVarP(&valueToUpdate, "value", "v", "", "Value of the Elasticsearch cluster setting to update (required)")
-	err = cmdSettingUpdate.MarkFlagRequired("value")
-	if err != nil {
-		fmt.Printf("Error binding value configuration flag: %s \n", err)
-		os.Exit(1)
-	}
+	cmdSettingUpdate.Flags().StringVarP(&valueToUpdate, "value", "v", "", "Value of the Elasticsearch cluster setting to update (can't be used with \"--remove\")")
+
+	cmdSettingUpdate.Flags().BoolVar(&removeValue, "remove", false, "Remove provided cluster setting, resetting it to default configuration (can't be used with \"--value|-v\")")
 
 	cmdSetting.AddCommand(cmdSettingUpdate)
 	rootCmd.AddCommand(cmdSetting)
@@ -41,18 +40,36 @@ var cmdSettingUpdate = &cobra.Command{
 	Long:  `This command will update the cluster's settings with the provided value.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
+		if cmd.Flags().Changed("value") && cmd.Flags().Changed("remove") {
+			fmt.Println("Can't set both \"--value|-v\" and \"--remove\" options")
+			fmt.Print(cmd.UsageString())
+			os.Exit(1)
+		}
+		if !cmd.Flags().Changed("value") && !cmd.Flags().Changed("remove") {
+			fmt.Println("Error: requires one of \"--value|-v\" or \"--remove\"")
+			fmt.Print(cmd.UsageString())
+			os.Exit(1)
+		}
 		v := getClient()
 
-		existingValue, newValue, err := v.SetClusterSetting(settingToUpdate, valueToUpdate)
+		var ptrValueToUpdate *string
+
+		if removeValue {
+			ptrValueToUpdate = nil
+		} else {
+			ptrValueToUpdate = &valueToUpdate
+		}
+
+		existingValue, newValue, err := v.SetClusterSetting(settingToUpdate, ptrValueToUpdate)
 
 		if err != nil {
-			fmt.Printf("Error when trying to update \"%s\" to \"%s\n", settingToUpdate, valueToUpdate)
+			fmt.Printf("Error when trying to update \"%s\" to \"%s\"\n", settingToUpdate, printableNil(ptrValueToUpdate))
 			fmt.Printf("Error is: %s\n", err)
 			os.Exit(1)
 		}
 
 		fmt.Printf("Updated setting %s\n", settingToUpdate)
-		fmt.Printf("\tOld value: %s\n", existingValue)
-		fmt.Printf("\tNew value: %s\n", newValue)
+		fmt.Printf("\tOld value: %s\n", printableNil(existingValue))
+		fmt.Printf("\tNew value: %s\n", printableNil(newValue))
 	},
 }

--- a/script/integration-test
+++ b/script/integration-test
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -e
 
+# Before we start, check if "vm.max_map_count" is correctly set, or the Docker containers will silently fail and lock the test
+maxMap="$(sysctl vm.max_map_count | awk -F "= " '{print $2}')"
+if [[ $maxMap -lt 262144 ]]
+then 
+    # incorrect config, won't work
+    echo "You need to increase vm.max_map_count to at least 262144 before Elasticsearch will start"
+    echo "Currently set to $maxMap"
+    echo "Run \"sudo sysctl -w vm.max_map_count=262144\" and start the test again."
+    exit 1
+fi
+
+
 # Run regular unit tests first
 ./script/test
 


### PR DESCRIPTION
Sorry I've been sitting on this one for a while, got busy.

This adds the ability to "null" settings when using `SetClusterSetting()`.
fixes #68 

The function signature is now 
```go
SetClusterSetting(setting string, value *string) (*string, *string, error)
```
and if you pass a nil `*string` as the new `value` it will reset that `setting` in Elasticsearch to its default value.

It also returns a `*string` as the `existingValue` and `newValue`. This allows you to save the original state of a potential null/unset setting and use it in a second call to `SetClusterSetting()` to reset the original state after the operation has finished. 

```go
oldSetting, _, err := v.SetClusterSetting("indices.recovery.max_bytes_per_sec", "1000mb")
  if err != nil {
    log.Printf("failed to set recovery max bytes cluster setting")
    return
}
defer func() {
  v.SetClusterSetting("indices.recovery.max_bytes_per_sec", oldSetting)
}()
```
In this example the `indices.recovery.max_bytes_per_sec` is probably unset (default) and should be reset to its `null` state when the shard migration is complete.

Other random stuff:
* Added debug message if there's an issue in the test server function `buildTestServer`, I had an extra space in the body and it took me way too long to figure it out.
* Added a small check to the integration test script file.
* Added `stringToPointer(v string) *string` helper function.
* New `go.mod` entry for `github.com/spf13/pflag`, not sure how this one wasn't already there as it's required by `github.com/spf13/cobra`.

Passes unit tests and integration tests.