### PR TITLE
Deprecate NewClient

### DIFF
--- a/es.go
+++ b/es.go
@@ -253,10 +253,18 @@ type Token struct {
 
 //Initialize a new vulcanizer client to use.
 func NewClient(host string, port int) *Client {
-	if port > 0 {
-		return &Client{Host: host, Port: port}
+	secure := false
+	if strings.HasPrefix(host, "https://") {
+		secure = true
+		host = strings.TrimPrefix(host, "https://")
+	} else if strings.HasPrefix(host, "http://") {
+		host = strings.TrimPrefix(host, "http://")
 	}
-	return &Client{Host: host}
+
+	if port > 0 {
+		return &Client{Host: host, Port: port, Secure: secure}
+	}
+	return &Client{Host: host, Secure: secure}
 }
 
 const clusterSettingsPath = "_cluster/settings"

--- a/es.go
+++ b/es.go
@@ -252,19 +252,12 @@ type Token struct {
 }
 
 //Initialize a new vulcanizer client to use.
+// Deprecated: NewClient has been deprecated in favor of using struct initialization.
 func NewClient(host string, port int) *Client {
-	secure := false
-	if strings.HasPrefix(host, "https://") {
-		secure = true
-		host = strings.TrimPrefix(host, "https://")
-	} else if strings.HasPrefix(host, "http://") {
-		host = strings.TrimPrefix(host, "http://")
-	}
-
 	if port > 0 {
-		return &Client{Host: host, Port: port, Secure: secure}
+		return &Client{Host: host, Port: port}
 	}
-	return &Client{Host: host, Secure: secure}
+	return &Client{Host: host}
 }
 
 const clusterSettingsPath = "_cluster/settings"

--- a/es_test.go
+++ b/es_test.go
@@ -1855,3 +1855,19 @@ func TestGetShardRecoveryRemaining(t *testing.T) {
 
 	assert.Equal(t, estRemaining, time.Hour*6)
 }
+
+func TestNewClientSecure(t *testing.T) {
+	client := NewClient("https://somehost.com", 0)
+	assert.Equal(t, client.Secure, true)
+	assert.Equal(t, client.Host, "somehost.com")
+}
+
+func TestNewClientInsecure(t *testing.T) {
+	client := NewClient("http://somehost.com", 0)
+	assert.Equal(t, client.Secure, false)
+	assert.Equal(t, client.Host, "somehost.com")
+
+	client = NewClient("somehost.com", 0)
+	assert.Equal(t, client.Secure, false)
+	assert.Equal(t, client.Host, "somehost.com")
+}

--- a/es_test.go
+++ b/es_test.go
@@ -1855,19 +1855,3 @@ func TestGetShardRecoveryRemaining(t *testing.T) {
 
 	assert.Equal(t, estRemaining, time.Hour*6)
 }
-
-func TestNewClientSecure(t *testing.T) {
-	client := NewClient("https://somehost.com", 0)
-	assert.Equal(t, client.Secure, true)
-	assert.Equal(t, client.Host, "somehost.com")
-}
-
-func TestNewClientInsecure(t *testing.T) {
-	client := NewClient("http://somehost.com", 0)
-	assert.Equal(t, client.Secure, false)
-	assert.Equal(t, client.Host, "somehost.com")
-
-	client = NewClient("somehost.com", 0)
-	assert.Equal(t, client.Secure, false)
-	assert.Equal(t, client.Host, "somehost.com")
-}


### PR DESCRIPTION
~This PR allows the use of `https` endpoints by setting `Client.Secure` field base on assumptions made by the url being passed to `vulcanizer.NewClient`.~

This PR deprecates the `vulcanizer.NewClient` function in favor of using struct initialization
```go
client := vulcanizer.Client{
  Host: host,
  Port: port,
  Secure: true,
  ...
}
```