### PR TITLE
Adds a short flag for nodeallocations

### DIFF
--- a/pkg/cli/node_allocation.go
+++ b/pkg/cli/node_allocation.go
@@ -8,7 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var shortTableOutput bool
+
 func init() {
+	cmdNodeAllocations.Flags().BoolVarP(&shortTableOutput, "short", "s", false, "Shorter, more compact table output")
 	rootCmd.AddCommand(cmdNodeAllocations)
 }
 
@@ -27,29 +30,54 @@ var cmdNodeAllocations = &cobra.Command{
 			os.Exit(1)
 		}
 
-		header := []string{"Master", "Role", "Name", "Disk Avail", "Disk Indices", "Disk Percent", "Disk Total", "Disk Used", "Shards", "Ip", "Id", "JDK", "Version"}
-		rows := [][]string{}
-		sort.Slice(nodes, func(i, j int) bool {
-			return nodes[i].Name < nodes[j].Name
-		})
-		for _, node := range nodes {
-			row := []string{
-				node.Master,
-				node.Role,
-				node.Name,
-				node.DiskAvail,
-				node.DiskIndices,
-				node.DiskPercent,
-				node.DiskTotal,
-				node.DiskUsed,
-				node.Shards,
-				node.Ip,
-				node.Id,
-				node.Jdk,
-				node.Version,
-			}
+		var header []string
+		var rows [][]string
+		if shortTableOutput {
+			header = []string{"Role", "Name", "Avail", "Used", "Total", "%", "Indices", "Shards", "Ip"}
+			rows = [][]string{}
+			sort.Slice(nodes, func(i, j int) bool {
+				return nodes[i].Name < nodes[j].Name
+			})
+			for _, node := range nodes {
+				row := []string{
+					fmt.Sprintf("%s%s", node.Master, node.Role),
+					node.Name,
+					node.DiskAvail,
+					node.DiskUsed,
+					node.DiskTotal,
+					node.DiskPercent,
+					node.DiskIndices,
+					node.Shards,
+					node.Ip,
+				}
 
-			rows = append(rows, row)
+				rows = append(rows, row)
+			}
+		} else {
+			header = []string{"Master", "Role", "Name", "Disk Avail", "Disk Indices", "Disk Percent", "Disk Total", "Disk Used", "Shards", "Ip", "Id", "JDK", "Version"}
+			rows = [][]string{}
+			sort.Slice(nodes, func(i, j int) bool {
+				return nodes[i].Name < nodes[j].Name
+			})
+			for _, node := range nodes {
+				row := []string{
+					node.Master,
+					node.Role,
+					node.Name,
+					node.DiskAvail,
+					node.DiskIndices,
+					node.DiskPercent,
+					node.DiskTotal,
+					node.DiskUsed,
+					node.Shards,
+					node.Ip,
+					node.Id,
+					node.Jdk,
+					node.Version,
+				}
+
+				rows = append(rows, row)
+			}
 		}
 
 		table := renderTable(rows, header)


### PR DESCRIPTION
Makes the information fit a smaller screen and reorders it a bit for clarity.

This is just a small addition I've been using as the default table is way too big and contains a lot of info I don't need when I just want a quick overview. 
With the shorter table it's easier to quickly parse information and how much disk is left.

```
vulcanizer -c testing nodeallocations -s
+--------+---------------------+---------+--------+---------+---+---------+--------+-----------------+
|  ROLE  |        NAME         |  AVAIL  |  USED  |  TOTAL  | % | INDICES | SHARDS |       IP        |
+--------+---------------------+---------+--------+---------+---+---------+--------+-----------------+
| -dilt  | testing-es-data-0   | 1.4tb   | 92.4mb | 1.4tb   | 0 | 92.2kb  | 2      | 100.96.75.65    |
| -dilt  | testing-es-data-1   | 1.4tb   | 92.5mb | 1.4tb   | 0 | 84.3kb  | 2      | 100.125.163.129 |
| -dilt  | testing-es-data-2   | 1.4tb   | 92.4mb | 1.4tb   | 0 | 92.2kb  | 2      | 100.118.110.129 |
| -dilmt | testing-es-master-0 | 956.9mb | 18.9mb | 975.8mb | 1 | 93.8kb  | 2      | 100.121.227.1   |
| *dilmt | testing-es-master-1 | 956.9mb | 18.9mb | 975.8mb | 1 | 65kb    | 2      | 100.96.22.65    |
| -dilmt | testing-es-master-2 | 956.9mb | 18.9mb | 975.8mb | 1 | 93.8kb  | 2      | 100.109.143.129 |
+--------+---------------------+---------+--------+---------+---+---------+--------+-----------------+

```