### PR TITLE
Add command to reload secure settings

### DIFF
--- a/es_test.go
+++ b/es_test.go
@@ -1882,3 +1882,70 @@ func TestGetShardRecoveryRemaining(t *testing.T) {
 
 	assert.Equal(t, estRemaining, time.Hour*6)
 }
+
+func TestReloadSecureSettings(t *testing.T) {
+	serverSetup := &ServerSetup{
+		Method:   "POST",
+		Path:     "/_nodes/reload_secure_settings",
+		Response: `{"_nodes":{"total":2,"successful":2,"failed":0},"cluster_name":"vulcanizer-elasticsearch-v7","nodes":{"iJeJx6ydSbKf_cvzDt1_gg":{"name":"vulcanizer-elasticsearch-v7"},"GXtqL0WdSguHQdo2xHNX_A":{"name":"vulcanizer-elasticsearch-v7-2","reload_exception":{"type":"illegal_state_exception","reason":"Keystore is missing"}}}}`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{serverSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	response, err := client.ReloadSecureSettings()
+
+	if err != nil {
+		t.Errorf("Unexpected error, get %s", err)
+	}
+
+	if response.Summary.Successful != 2 {
+		t.Errorf("Expected response to parse 2 successful nodes from summary, got %#v", response)
+	}
+
+	goodNode := response.Nodes["iJeJx6ydSbKf_cvzDt1_gg"]
+	badNode := response.Nodes["GXtqL0WdSguHQdo2xHNX_A"]
+
+	if goodNode.Name != "vulcanizer-elasticsearch-v7" && goodNode.ReloadException != nil {
+		t.Errorf("Expected to parse good node response correctly, got %#v", goodNode)
+	}
+
+	if badNode.Name != "vulcanizer-elasticsearch-v7-2" && badNode.ReloadException.Reason != "Keystore is missing" {
+		t.Errorf("Expected to parse bad node response correctly, got %#v", goodNode)
+	}
+}
+
+func TestReloadSecureSettingsWithPassword(t *testing.T) {
+	serverSetup := &ServerSetup{
+		Method:   "POST",
+		Path:     "/_nodes/reload_secure_settings",
+		Body:     `{"secure_settings_password":"123456"}`,
+		Response: `{"_nodes":{"total":2,"successful":2,"failed":0},"cluster_name":"vulcanizer-elasticsearch-v7","nodes":{"iJeJx6ydSbKf_cvzDt1_gg":{"name":"vulcanizer-elasticsearch-v7"},"GXtqL0WdSguHQdo2xHNX_A":{"name":"vulcanizer-elasticsearch-v7-2","reload_exception":{"type":"illegal_state_exception","reason":"Keystore is missing"}}}}`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{serverSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	response, err := client.ReloadSecureSettingsWithPassword("123456")
+
+	if err != nil {
+		t.Errorf("Unexpected error, get %s", err)
+	}
+
+	if response.Summary.Successful != 2 {
+		t.Errorf("Expected response to parse 2 successful nodes from summary, got %#v", response)
+	}
+
+	goodNode := response.Nodes["iJeJx6ydSbKf_cvzDt1_gg"]
+	badNode := response.Nodes["GXtqL0WdSguHQdo2xHNX_A"]
+
+	if goodNode.Name != "vulcanizer-elasticsearch-v7" && goodNode.ReloadException != nil {
+		t.Errorf("Expected to parse good node response correctly, got %#v", goodNode)
+	}
+
+	if badNode.Name != "vulcanizer-elasticsearch-v7-2" && badNode.ReloadException.Reason != "Keystore is missing" {
+		t.Errorf("Expected to parse bad node response correctly, got %#v", goodNode)
+	}
+}

--- a/pkg/cli/settings.go
+++ b/pkg/cli/settings.go
@@ -9,7 +9,14 @@ import (
 )
 
 func init() {
+	setupReloadSecureCommand()
+
 	rootCmd.AddCommand(cmdSettings)
+}
+
+func setupReloadSecureCommand() {
+	cmdSettingsReloadSecure.Flags().StringP("keystore_password", "", "", "Keystore password to reload the secure settings if enabled")
+	cmdSettings.AddCommand(cmdSettingsReloadSecure)
 }
 
 func printSettings(settings []vulcanizer.Setting, name string) {
@@ -51,5 +58,53 @@ var cmdSettings = &cobra.Command{
 
 		printSettings(clusterSettings.PersistentSettings, "persistent settings")
 		printSettings(clusterSettings.TransientSettings, "transient settings")
+	},
+}
+
+var cmdSettingsReloadSecure = &cobra.Command{
+	Use:   "reload",
+	Short: "Reload the secure settings.",
+	Long:  `This command calls the reload secure settings API on all nodes.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		v := getClient()
+
+		password, err := cmd.Flags().GetString("keystore_password")
+		if err != nil {
+			fmt.Printf("Could not retrieve required argument: keystore_password. Error: %s\n", err)
+			os.Exit(1)
+		}
+
+		var reloadResponse vulcanizer.ReloadSecureSettingsResponse
+		var reloadError error
+
+		if password == "" {
+			reloadResponse, reloadError = v.ReloadSecureSettings()
+		} else {
+			reloadResponse, reloadError = v.ReloadSecureSettingsWithPassword(password)
+		}
+
+		if reloadError != nil {
+			fmt.Printf("Error reloading secure settings settings: %s\n", reloadError)
+			os.Exit(1)
+		}
+
+		header := []string{"Node", "Reload status"}
+		rows := [][]string{}
+
+		for _, node := range reloadResponse.Nodes {
+			row := []string{node.Name}
+
+			if node.ReloadException == nil {
+				row = append(row, "Successfully reloaded")
+			} else {
+				row = append(row, fmt.Sprintf("Exception type: %s, reason: %s", node.ReloadException.Type, node.ReloadException.Reason))
+			}
+
+			rows = append(rows, row)
+		}
+
+		table := renderTable(rows, header)
+		fmt.Println(table)
 	},
 }


### PR DESCRIPTION
This PR adds a library function and CLI command to call the reload secure settings API: https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-reload-secure-settings.html
