### PR TITLE
adds GetHotThreads to es client

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.44.2
+          version: v1.46.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/es.go
+++ b/es.go
@@ -1513,3 +1513,13 @@ func (c *Client) ReloadSecureSettingsWithPassword(password string) (ReloadSecure
 
 	return response, nil
 }
+
+// GetHotThreads allows to get the current hot threads on each node in the cluster
+func (c *Client) GetHotThreads() (string, error) {
+	body, err := handleErrWithBytes(c.buildGetRequest("_nodes/hot_threads"))
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}

--- a/es_test.go
+++ b/es_test.go
@@ -2065,7 +2065,6 @@ func TestGetHotThreads(t *testing.T) {
 	client := NewClient(host, port)
 
 	hotThreads, err := client.GetHotThreads()
-
 	if err != nil {
 		t.Fatalf("Unexpected error expected nil, got %s", err)
 	}


### PR DESCRIPTION
This PR adds the `GetHotThreads` method to the es client, so we can move forward with https://github.com/github/vulcan-go/issues/150