### PR TITLE
adds GetNodesHotThreads method to es client

### DIFF
--- a/es.go
+++ b/es.go
@@ -1514,9 +1514,20 @@ func (c *Client) ReloadSecureSettingsWithPassword(password string) (ReloadSecure
 	return response, nil
 }
 
-// GetHotThreads allows to get the current hot threads on each node in the cluster
+// GetHotThreads allows to get the current hot threads on each node on the cluster
 func (c *Client) GetHotThreads() (string, error) {
 	body, err := handleErrWithBytes(c.buildGetRequest("_nodes/hot_threads"))
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// GetNodesHotThreads allows to get the current hot threads on given nodes on the cluster
+func (c *Client) GetNodesHotThreads(nodesIDs string) (string, error) {
+	url := fmt.Sprintf("_nodes/%s/hot_threads", strings.ReplaceAll(nodesIDs, " ", ""))
+	body, err := handleErrWithBytes(c.buildGetRequest(url))
 	if err != nil {
 		return "", err
 	}

--- a/es_test.go
+++ b/es_test.go
@@ -2073,3 +2073,26 @@ func TestGetHotThreads(t *testing.T) {
 		t.Errorf("Unexpected response. got %v want %v", hotThreads, testSetup.Response)
 	}
 }
+
+func TestGetNodesHotThreads(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method: "GET",
+		Path:   "/_nodes/nodeid1,nodeid2/hot_threads",
+		Response: `
+::: {Mister Sinister}{nodeid1}{127.0.0.1}{127.0.0.1:9300}
+   Hot threads at 2022-08-04T20:30:34.357Z, interval=500ms, busiestThreads=3, ignoreIdleThreads=true:`,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	hotThreads, err := client.GetNodesHotThreads("nodeid1, nodeid2")
+	if err != nil {
+		t.Fatalf("Unexpected error expected nil, got %s", err)
+	}
+
+	if hotThreads != testSetup.Response {
+		t.Errorf("Unexpected response. got %v want %v", hotThreads, testSetup.Response)
+	}
+}


### PR DESCRIPTION
This PR adds the method `GetNodesHotThreads` that allows users to pass the nodes ids they want to check the hot threads against.