### PR TITLE
adds ClusterAllocationExplain method

### DIFF
--- a/es.go
+++ b/es.go
@@ -1586,6 +1586,7 @@ type ClusterAllocationExplainRequest struct {
 }
 
 // ClusterAllocationExplain provides an explanation for a shard’s current allocation.
+// For more info, please check https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-allocation-explain.html
 func (c *Client) ClusterAllocationExplain(req *ClusterAllocationExplainRequest) (string, error) {
 	agent := c.buildGetRequest("_cluster/allocation/explain?pretty").
 		Set("Content-Type", "application/json")

--- a/es.go
+++ b/es.go
@@ -1596,8 +1596,7 @@ func (c *Client) ClusterAllocationExplain(req *ClusterAllocationExplainRequest, 
 
 	agent := c.buildGetRequest(urlBuilder.String())
 	if req != nil {
-		agent.Set("Content-Type", "application/json").
-			Send(req)
+		agent.Set("Content-Type", "application/json").Send(req)
 	}
 
 	body, err := handleErrWithBytes(agent)

--- a/es.go
+++ b/es.go
@@ -1567,3 +1567,37 @@ func (c *Client) GetNodesHotThreads(nodesIDs []string) (string, error) {
 
 	return string(body), nil
 }
+
+// ClusterAllocationExplainRequest represents request data that can be sent to
+// `_cluster/allocation/explain` calls
+type ClusterAllocationExplainRequest struct {
+	// Specifies the node ID or the name of the node to only explain a shard that
+	// is currently located on the specified node.
+	CurrentNode string `json:"current_node,omitempty"`
+
+	// Specifies the name of the index that you would like an explanation for.
+	Index string `json:"index,omitempty"`
+
+	// If true, returns explanation for the primary shard for the given shard ID.
+	Primary bool `json:"primary,omitempty"`
+
+	// Specifies the ID of the shard that you would like an explanation for.
+	Shard string `json:"shard,omitempty"`
+}
+
+// ClusterAllocationExplain provides an explanation for a shard’s current allocation.
+func (c *Client) ClusterAllocationExplain(req *ClusterAllocationExplainRequest) (string, error) {
+	agent := c.buildGetRequest("_cluster/allocation/explain?pretty").
+		Set("Content-Type", "application/json")
+
+	if req != nil {
+		agent.Send(req)
+	}
+
+	body, err := handleErrWithBytes(agent)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}

--- a/es.go
+++ b/es.go
@@ -1587,12 +1587,17 @@ type ClusterAllocationExplainRequest struct {
 
 // ClusterAllocationExplain provides an explanation for a shard’s current allocation.
 // For more info, please check https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-allocation-explain.html
-func (c *Client) ClusterAllocationExplain(req *ClusterAllocationExplainRequest) (string, error) {
-	agent := c.buildGetRequest("_cluster/allocation/explain?pretty").
-		Set("Content-Type", "application/json")
+func (c *Client) ClusterAllocationExplain(req *ClusterAllocationExplainRequest, prettyOutput bool) (string, error) {
+	var urlBuilder strings.Builder
+	urlBuilder.WriteString("_cluster/allocation/explain")
+	if prettyOutput {
+		urlBuilder.WriteString("?pretty")
+	}
 
+	agent := c.buildGetRequest(urlBuilder.String())
 	if req != nil {
-		agent.Send(req)
+		agent.Set("Content-Type", "application/json").
+			Send(req)
 	}
 
 	body, err := handleErrWithBytes(agent)

--- a/es_test.go
+++ b/es_test.go
@@ -2153,7 +2153,7 @@ func TestClusterAllocationExplain(t *testing.T) {
 
 			_, err := client.ClusterAllocationExplain(tc.request)
 			if err != nil {
-				t.Fatalf("Unexpected error expected nil, got %s", err)
+				t.Fatalf("Unexpected error. expected nil, got %s", err)
 			}
 		})
 	}

--- a/es_test.go
+++ b/es_test.go
@@ -2096,3 +2096,65 @@ func TestGetNodesHotThreads(t *testing.T) {
 		t.Errorf("Unexpected response. got %v want %v", hotThreads, testSetup.Response)
 	}
 }
+
+func TestClusterAllocationExplain(t *testing.T) {
+	tests := []struct {
+		name         string
+		request      *ClusterAllocationExplainRequest
+		expectedBody string
+	}{
+		{
+			name:         "with nil request",
+			request:      nil,
+			expectedBody: "",
+		},
+		{
+			name: "with current_node set",
+			request: &ClusterAllocationExplainRequest{
+				CurrentNode: "test-node",
+			},
+			expectedBody: `{"current_node":"test-node"}`,
+		},
+		{
+			name: "with index set",
+			request: &ClusterAllocationExplainRequest{
+				Index: "test-index",
+			},
+			expectedBody: `{"index":"test-index"}`,
+		},
+		{
+			name: "with primary set",
+			request: &ClusterAllocationExplainRequest{
+				Primary: true,
+			},
+			expectedBody: `{"primary":true}`,
+		},
+		{
+			name: "with shard set",
+			request: &ClusterAllocationExplainRequest{
+				Shard: "test-shard",
+			},
+			expectedBody: `{"shard":"test-shard"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			testSetup := &ServerSetup{
+				Method: "GET",
+				Path:   "/_cluster/allocation/explain",
+				Body:   tc.expectedBody,
+			}
+
+			host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+			defer ts.Close()
+			client := NewClient(host, port)
+
+			_, err := client.ClusterAllocationExplain(tc.request)
+			if err != nil {
+				t.Fatalf("Unexpected error expected nil, got %s", err)
+			}
+		})
+	}
+}

--- a/es_test.go
+++ b/es_test.go
@@ -34,7 +34,7 @@ func buildTestServer(t *testing.T, setups []*ServerSetup, tls bool) *httptest.Se
 				setup.extraChecksFn(t, r)
 			}
 			// Extra piece of debug incase there's a typo in your test's response, like a rogue space somewhere
-			if r.Method == setup.Method && r.URL.String() == setup.Path && requestBody != setup.Body {
+			if r.Method == setup.Method && r.URL.EscapedPath() == setup.Path && requestBody != setup.Body {
 				t.Fatalf("request body not matching: %s != %s", requestBody, setup.Body)
 			}
 

--- a/script/test
+++ b/script/test
@@ -11,4 +11,4 @@ else
     go test -v github.com/github/vulcanizer/...
 fi
 
-$(go env GOPATH)/bin/golangci-lint -v run
+golangci-lint -v run

--- a/script/test
+++ b/script/test
@@ -11,4 +11,4 @@ else
     go test -v github.com/github/vulcanizer/...
 fi
 
-golangci-lint -v run
+$(go env GOPATH)/bin/golangci-lint -v run


### PR DESCRIPTION
This PR adds the adds `ClusterAllocationExplain` method to the ES client. For more info, check https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-allocation-explain.html 