### PR TITLE
changes shard field from string to *int in ClusterAllocationExplainRe…

### DIFF
--- a/es.go
+++ b/es.go
@@ -1582,7 +1582,7 @@ type ClusterAllocationExplainRequest struct {
 	Primary bool `json:"primary,omitempty"`
 
 	// Specifies the ID of the shard that you would like an explanation for.
-	Shard string `json:"shard,omitempty"`
+	Shard *int `json:"shard,omitempty"`
 }
 
 // ClusterAllocationExplain provides an explanation for a shard’s current allocation.

--- a/es_test.go
+++ b/es_test.go
@@ -2103,6 +2103,7 @@ func TestGetNodesHotThreads(t *testing.T) {
 }
 
 func TestClusterAllocationExplain(t *testing.T) {
+	shardID := 0
 	tests := []struct {
 		name         string
 		request      *ClusterAllocationExplainRequest
@@ -2138,9 +2139,9 @@ func TestClusterAllocationExplain(t *testing.T) {
 		{
 			name: "with shard set",
 			request: &ClusterAllocationExplainRequest{
-				Shard: "test-shard",
+				Shard: &shardID,
 			},
-			expectedBody: `{"shard":"test-shard"}`,
+			expectedBody: `{"shard":0}`,
 		},
 		{
 			name:         "with pretty output",


### PR DESCRIPTION
This PR fixes the type of the field `Shard` in the `ClusterAllocationExplainRequest` struct.  It changes from `string` to `*int`.