### PR TITLE
Reroute failed shards command is added

### DIFF
--- a/es.go
+++ b/es.go
@@ -1630,6 +1630,21 @@ type AllocateStalePrimary struct {
 	AcceptDataLoss bool `json:"accept_data_loss,omitempty"`
 }
 
+// Reroute allows to change the allocation of individual shards in the cluster.
+func (c *Client) Reroute() error {
+	var urlBuilder strings.Builder
+	urlBuilder.WriteString("_cluster/reroute?retry_failed=true")
+
+	agent := c.buildPostRequest(urlBuilder.String())
+
+	_, err := handleErrWithBytes(agent)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // AllocateStalePrimary allows to manually allocate a stale primary shard to a specific node
 func (c *Client) AllocateStalePrimaryShard(node, index string, shard int) error {
 	var urlBuilder strings.Builder

--- a/es.go
+++ b/es.go
@@ -1630,8 +1630,8 @@ type AllocateStalePrimary struct {
 	AcceptDataLoss bool `json:"accept_data_loss,omitempty"`
 }
 
-// Reroute allows to change the allocation of individual shards in the cluster.
-func (c *Client) Reroute() error {
+// RerouteWithRetryFailed retries allocation of shards that are blocked due to too many subsequent allocation failures.
+func (c *Client) RerouteWithRetryFailed() error {
 	var urlBuilder strings.Builder
 	urlBuilder.WriteString("_cluster/reroute?retry_failed=true")
 

--- a/es_test.go
+++ b/es_test.go
@@ -2190,7 +2190,7 @@ func TestReroute(t *testing.T) {
 	defer ts.Close()
 	client := NewClient(host, port)
 
-	err := client.Reroute()
+	err := client.RerouteWithRetryFailed()
 	if err != nil {
 		t.Fatalf("Unexpected error expected nil, got %s", err)
 	}

--- a/es_test.go
+++ b/es_test.go
@@ -2180,6 +2180,22 @@ func TestClusterAllocationExplain(t *testing.T) {
 	}
 }
 
+func TestReroute(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method: "POST",
+		Path:   "/_cluster/reroute",
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	err := client.Reroute()
+	if err != nil {
+		t.Fatalf("Unexpected error expected nil, got %s", err)
+	}
+}
+
 func TestAllocateStalePrimaryShard(t *testing.T) {
 	testSetup := &ServerSetup{
 		Method: "POST",


### PR DESCRIPTION
This PR adds basic reroute command for retrying allocate failed shards.