### PR TITLE
Removing ILM Policy from Index is added

### DIFF
--- a/es.go
+++ b/es.go
@@ -1673,3 +1673,15 @@ func (c *Client) AllocateStalePrimaryShard(node, index string, shard int) error 
 
 	return nil
 }
+
+// RemoveIndexILMPolicy removes the ILM policy from the index
+func (c *Client) RemoveIndexILMPolicy(index string) error {
+	agent := c.buildPostRequest(fmt.Sprintf("%s/_ilm/remove", index))
+
+	_, err := handleErrWithBytes(agent)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/es.go
+++ b/es.go
@@ -710,6 +710,18 @@ func (c *Client) GetIndices(index string) ([]Index, error) {
 	return indices, nil
 }
 
+// Get a subset of indices including hidden ones
+func (c *Client) GetHiddenIndices(index string) ([]Index, error) {
+	var indices []Index
+	err := handleErrWithStruct(c.buildGetRequest(fmt.Sprintf("_cat/indices/%s?h=health,status,index,pri,rep,store.size,docs.count&expand_wildcards=open,closed,hidden", index)), &indices)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return indices, nil
+}
+
 // Get all the aliases in the cluster.
 //
 // Use case: You want to see some basic info on all the aliases of the cluster
@@ -1681,6 +1693,18 @@ func (c *Client) RemoveIndexILMPolicy(index string) error {
 	_, err := handleErrWithBytes(agent)
 	if err != nil {
 		return err
+	}
+
+	ilmHistoryIndices, err := c.GetHiddenIndices(fmt.Sprintf("%s*.ds-ilm-history-*", index))
+	if err != nil {
+		return err
+	}
+
+	for _, ilmHistoryIndex := range ilmHistoryIndices {
+		err = c.DeleteIndex(ilmHistoryIndex.Name)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/es_test.go
+++ b/es_test.go
@@ -2212,3 +2212,19 @@ func TestAllocateStalePrimaryShard(t *testing.T) {
 		t.Fatalf("Unexpected error. expected nil, got %s", err)
 	}
 }
+
+func TestRemoveIndexILMPolicy(t *testing.T) {
+	testSetup := &ServerSetup{
+		Method: "POST",
+		Path:   "/test-index/_ilm/remove",
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	err := client.RemoveIndexILMPolicy("test-index")
+	if err != nil {
+		t.Fatalf("Unexpected error. expected nil, got %s", err)
+	}
+}

--- a/es_test.go
+++ b/es_test.go
@@ -2214,12 +2214,17 @@ func TestAllocateStalePrimaryShard(t *testing.T) {
 }
 
 func TestRemoveIndexILMPolicy(t *testing.T) {
-	testSetup := &ServerSetup{
+	ilmRemoveTestSetup := &ServerSetup{
 		Method: "POST",
 		Path:   "/test-index/_ilm/remove",
 	}
+	getIndicesTestSetup := &ServerSetup{
+		Method:   "GET",
+		Path:     "/_cat/indices/test-index*.ds-ilm-history-*",
+		Response: "[]",
+	}
 
-	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	host, port, ts := setupTestServers(t, []*ServerSetup{ilmRemoveTestSetup, getIndicesTestSetup})
 	defer ts.Close()
 	client := NewClient(host, port)
 


### PR DESCRIPTION
This PR adds command for removing ILM Policy from an index.