### PR TITLE
Add GetShardRecoveryWithQueryParams

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.15
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.15
+          go-version: '1.15'
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.7.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.46.2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,7 +13,6 @@ linters-settings:
 
 linters:
   enable:
-    - deadcode
     - depguard
     - errcheck
     - exportloopref
@@ -30,11 +29,9 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
   disable:
     - gochecknoglobals # we allow global variables in packages
     - gochecknoinits   # we allow inits in packages

--- a/es.go
+++ b/es.go
@@ -1518,7 +1518,7 @@ func (c *Client) GetShardRecoveryWithQueryParams(nodes []string, params map[stri
 	var allRecoveries []ShardRecovery
 	uri := "_cat/recovery"
 
-	var queryStrings []string
+	queryStrings := []string{}
 	for param, val := range params {
 		queryStrings = append(queryStrings, fmt.Sprintf("%s=%s", param, val))
 	}


### PR DESCRIPTION
Adds a new method to `Client` to allow passing in a simple map of query parameters to be sent to `_cat/recovery`. This new method opens up some compatibility with later versions of Elasticsearch that changed the default units.