### PR TITLE
Set goreleaser version explicitly

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,7 +23,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: 'v1.14.0'
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`latest` has compatability issues. Should lock the version down and tackle that later. This version number is likely what the previous release used.