### PR TITLE
Adding a license cluster command

### DIFF
--- a/es.go
+++ b/es.go
@@ -1803,7 +1803,7 @@ func (c *Client) RemoveIndexILMPolicy(index string) error {
 	return nil
 }
 
-// Function called LicenseCluster. This function takes a json document as a string which is the license to apply to the Elasticsearch cluster.
+// LicenseCluster takes in the Elasticsearch license encoded as a string
 func (c *Client) LicenseCluster(license string) error {
 	// If the license is empty, return an error
 	if license == "" {

--- a/es.go
+++ b/es.go
@@ -1802,3 +1802,24 @@ func (c *Client) RemoveIndexILMPolicy(index string) error {
 
 	return nil
 }
+
+// Function called LicenseCluster. This function takes a json document as a string which is the license to apply to the Elasticsearch cluster.
+func (c *Client) LicenseCluster(license string) error {
+	// If the license is empty, return an error
+	if license == "" {
+		return errors.New("license is required")
+	}
+
+	// Build the request to apply the license to the cluster
+	agent := c.buildPutRequest("_license").
+		Set("Content-Type", "application/json").
+		Send(license)
+
+	// Execute the request
+	_, err := handleErrWithBytes(agent)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/es_test.go
+++ b/es_test.go
@@ -2363,3 +2363,22 @@ func TestRemoveIndexILMPolicy(t *testing.T) {
 		t.Fatalf("Unexpected error. expected nil, got %s", err)
 	}
 }
+func TestLicenseCluster(t *testing.T) {
+	body := `{"license":{"start_date_in_millis":2728303200000,"uid":"asdfasdf-e"}}`
+
+	testSetup := &ServerSetup{
+		Method: "PUT",
+		Path:   "/_license",
+		Body:   body,
+	}
+
+	host, port, ts := setupTestServers(t, []*ServerSetup{testSetup})
+	defer ts.Close()
+	client := NewClient(host, port)
+
+	err := client.LicenseCluster(body)
+
+	if err != nil {
+		t.Errorf("Unexpected error expected nil, got %s", err)
+	}
+}


### PR DESCRIPTION
In order to securely add licensing to our Elasticsearch clusters I have added LicenseCluster action. This action takes in a string containing the json license and applies it to the cluster. 

This is just one component that will be used in the licensing workflow from `vulcan-go`. 

Tracking issue here: https://github.com/github/elasticsearch/issues/4211