### PR TITLE
Improving Security Posture

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version: '1.22'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@v3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.55.2

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version: '1.22'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3a919529898de77ec3da873e3063ca4b10e7f5cc
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.55.2

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: 1.22
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b
         with:
           version: 'v1.14.0'
           args: release --rm-dist

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,6 +1,10 @@
 ---
 name: Vulcanizer CI
 on: [push, pull_request]
+permissions: 
+  contents: read
+  actions: read
+  checks: write
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've just taken some time to improve the security posture of this repo:

1. Giving workflow steps narrowly scoped permissions
2. Pinning dependencies in workflows to explicit commit hashes

These are really just some cleanup items and this does not necessitate a release. 